### PR TITLE
Fix of #7 Pulse Stop

### DIFF
--- a/SpellActivationOverlay.lua
+++ b/SpellActivationOverlay.lua
@@ -72,18 +72,18 @@ local complexLocationTable = {
 	},
 }
 
-function SpellActivationOverlay_ShowAllOverlays(self, spellID, texturePath, positions, scale, r, g, b)
+function SpellActivationOverlay_ShowAllOverlays(self, spellID, texturePath, positions, scale, r, g, b, forcePulsePlay)
 	positions = strupper(positions);
 	if ( complexLocationTable[positions] ) then
 		for location, info in pairs(complexLocationTable[positions]) do
-			SpellActivationOverlay_ShowOverlay(self, spellID, texturePath, location, scale, r, g, b, info.vFlip, info.hFlip);
+			SpellActivationOverlay_ShowOverlay(self, spellID, texturePath, location, scale, r, g, b, info.vFlip, info.hFlip, forcePulsePlay);
 		end
 	else
-		SpellActivationOverlay_ShowOverlay(self, spellID, texturePath, positions, scale, r, g, b, false, false);
+		SpellActivationOverlay_ShowOverlay(self, spellID, texturePath, positions, scale, r, g, b, false, false, forcePulsePlay);
 	end
 end
 
-function SpellActivationOverlay_ShowOverlay(self, spellID, texturePath, position, scale, r, g, b, vFlip, hFlip)
+function SpellActivationOverlay_ShowOverlay(self, spellID, texturePath, position, scale, r, g, b, vFlip, hFlip, forcePulsePlay)
 	local overlay = SpellActivationOverlay_GetOverlay(self, spellID, position);
 	overlay.spellID = spellID;
 	overlay.position = position;
@@ -140,6 +140,9 @@ function SpellActivationOverlay_ShowOverlay(self, spellID, texturePath, position
 	overlay.animOut:Stop();	--In case we're in the process of animating this out.
 	PlaySound(SOUNDKIT.UI_POWER_AURA_GENERIC);
 	overlay:Show();
+	if ( forcePulsePlay ) then
+		overlay.pulse:Play();
+	end
 end
 
 function SpellActivationOverlay_GetOverlay(self, spellID, position)

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,9 @@
 ## SpellActivationOverlay Changelog
 
-#### v0.4.1-beta (2022-07-31)
+#### v0.4.1-beta (2022-08-xx)
 
 - New SAO: Paladin's Infusion of Light
+- Textures should keep pulsing after gaining/losing stacks
 
 #### v0.4.0-beta (2022-07-31)
 

--- a/classes/common.lua
+++ b/classes/common.lua
@@ -85,9 +85,9 @@ function SAO.GetActiveOverlay(self, spellID)
 end
 
 -- Add or refresh an overlay
-function SAO.ActivateOverlay(self, stacks, spellID, texture, positions, scale, r, g, b)
+function SAO.ActivateOverlay(self, stacks, spellID, texture, positions, scale, r, g, b, forcePulsePlay)
     self.ActiveOverlays[spellID] = stacks;
-    self.ShowAllOverlays(self.Frame, spellID, texture, positions, scale, r, g, b);
+    self.ShowAllOverlays(self.Frame, spellID, texture, positions, scale, r, g, b, forcePulsePlay);
 end
 
 -- Remove an overlay
@@ -142,7 +142,9 @@ function SAO.SPELL_AURA(self, ...)
             -- Deactivate old aura and activate the new one
             self:DeactivateOverlay(spellID);
             for _, aura in ipairs(auras[count]) do
-                self:ActivateOverlay(count, select(3,unpack(aura)));
+                local texture, positions, scale, r, g, b = select(4,unpack(aura));
+                local forcePulsePlay = true;
+                self:ActivateOverlay(count, spellID, texture, positions, scale, r, g, b, forcePulsePlay);
             end
         elseif (
             -- Aura is already visible and its number of stacks changed


### PR DESCRIPTION
Fix for #7 with the following solution:
- a new param can be passed when activating a SAO, to force-play a pulse effect
- by default this param is false
- this param is set if and only when gaining/losing stacks of an existing effect
- this param is *not* set when starting stacks (i.e., from 0 to 1) or when losing them all (i.e., from _n_ to 0)