### PR TITLE
Feature #8 Optional Pulse

### DIFF
--- a/SpellActivationOverlay.lua
+++ b/SpellActivationOverlay.lua
@@ -41,7 +41,7 @@ function SpellActivationOverlay_OnEvent(self, event, ...)
 	if ( event == "SPELL_ACTIVATION_OVERLAY_SHOW" ) then
 		local spellID, texture, positions, scale, r, g, b = ...;
 		if ( GetCVarBool("displaySpellActivationOverlays") ) then 
-			SpellActivationOverlay_ShowAllOverlays(self, spellID, texture, positions, scale, r, g, b)
+			SpellActivationOverlay_ShowAllOverlays(self, spellID, texture, positions, scale, r, g, b, true)
 		end
 	elseif ( event == "SPELL_ACTIVATION_OVERLAY_HIDE" ) then
 		local spellID = ...;
@@ -72,18 +72,18 @@ local complexLocationTable = {
 	},
 }
 
-function SpellActivationOverlay_ShowAllOverlays(self, spellID, texturePath, positions, scale, r, g, b, forcePulsePlay)
+function SpellActivationOverlay_ShowAllOverlays(self, spellID, texturePath, positions, scale, r, g, b, autoPulse, forcePulsePlay)
 	positions = strupper(positions);
 	if ( complexLocationTable[positions] ) then
 		for location, info in pairs(complexLocationTable[positions]) do
-			SpellActivationOverlay_ShowOverlay(self, spellID, texturePath, location, scale, r, g, b, info.vFlip, info.hFlip, forcePulsePlay);
+			SpellActivationOverlay_ShowOverlay(self, spellID, texturePath, location, scale, r, g, b, info.vFlip, info.hFlip, autoPulse, forcePulsePlay);
 		end
 	else
-		SpellActivationOverlay_ShowOverlay(self, spellID, texturePath, positions, scale, r, g, b, false, false, forcePulsePlay);
+		SpellActivationOverlay_ShowOverlay(self, spellID, texturePath, positions, scale, r, g, b, false, false, autoPulse, forcePulsePlay);
 	end
 end
 
-function SpellActivationOverlay_ShowOverlay(self, spellID, texturePath, position, scale, r, g, b, vFlip, hFlip, forcePulsePlay)
+function SpellActivationOverlay_ShowOverlay(self, spellID, texturePath, position, scale, r, g, b, vFlip, hFlip, autoPulse, forcePulsePlay)
 	local overlay = SpellActivationOverlay_GetOverlay(self, spellID, position);
 	overlay.spellID = spellID;
 	overlay.position = position;
@@ -143,6 +143,7 @@ function SpellActivationOverlay_ShowOverlay(self, spellID, texturePath, position
 	if ( forcePulsePlay ) then
 		overlay.pulse:Play();
 	end
+	overlay.pulse.autoPlay = autoPulse;
 end
 
 function SpellActivationOverlay_GetOverlay(self, spellID, position)
@@ -208,7 +209,9 @@ end
 function SpellActivationOverlayTexture_OnFadeInFinished(animGroup)
 	local overlay = animGroup:GetParent();
 	overlay:SetAlpha(1);
-	overlay.pulse:Play();
+	if ( overlay.pulse.autoPlay ) then
+		overlay.pulse:Play();
+	end
 end
 
 function SpellActivationOverlayTexture_OnFadeOutFinished(anim)

--- a/classes/common.lua
+++ b/classes/common.lua
@@ -23,8 +23,8 @@ SAO.ActiveOverlays = {}
 
 -- Utility function to register a new aura
 -- Arguments simply need to copy Retail's SPELL_ACTIVATION_OVERLAY_SHOW event arguments
-function SAO.RegisterAura(self, name, stacks, spellID, texture, positions, scale, r, g, b)
-    local aura = { name, stacks, spellID, self.TexName[texture], positions, scale, r, g, b }
+function SAO.RegisterAura(self, name, stacks, spellID, texture, positions, scale, r, g, b, autoPulse)
+    local aura = { name, stacks, spellID, self.TexName[texture], positions, scale, r, g, b, autoPulse }
     self.RegisteredAurasByName[name] = aura;
     if self.RegisteredAurasBySpellID[spellID] then
         if self.RegisteredAurasBySpellID[spellID][stacks] then
@@ -85,9 +85,9 @@ function SAO.GetActiveOverlay(self, spellID)
 end
 
 -- Add or refresh an overlay
-function SAO.ActivateOverlay(self, stacks, spellID, texture, positions, scale, r, g, b, forcePulsePlay)
+function SAO.ActivateOverlay(self, stacks, spellID, texture, positions, scale, r, g, b, autoPulse, forcePulsePlay)
     self.ActiveOverlays[spellID] = stacks;
-    self.ShowAllOverlays(self.Frame, spellID, texture, positions, scale, r, g, b, forcePulsePlay);
+    self.ShowAllOverlays(self.Frame, spellID, texture, positions, scale, r, g, b, autoPulse, forcePulsePlay);
 end
 
 -- Remove an overlay
@@ -142,9 +142,9 @@ function SAO.SPELL_AURA(self, ...)
             -- Deactivate old aura and activate the new one
             self:DeactivateOverlay(spellID);
             for _, aura in ipairs(auras[count]) do
-                local texture, positions, scale, r, g, b = select(4,unpack(aura));
-                local forcePulsePlay = true;
-                self:ActivateOverlay(count, spellID, texture, positions, scale, r, g, b, forcePulsePlay);
+                local texture, positions, scale, r, g, b, autoPulse = select(4,unpack(aura));
+                local forcePulsePlay = autoPulse;
+                self:ActivateOverlay(count, spellID, texture, positions, scale, r, g, b, autoPulse, forcePulsePlay);
             end
         elseif (
             -- Aura is already visible and its number of stacks changed

--- a/classes/deathknight.lua
+++ b/classes/deathknight.lua
@@ -1,8 +1,8 @@
 local AddonName, SAO = ...
 
 local function registerAuras(self)
-    self:RegisterAura("rime", 0, 59052, 450930, "Top", 1, 255, 255, 255);
-    self:RegisterAura("killing_machine", 0, 51124, 458740, "Left + Right (Flipped)", 1, 255, 255, 255);
+    self:RegisterAura("rime", 0, 59052, 450930, "Top", 1, 255, 255, 255, true);
+    self:RegisterAura("killing_machine", 0, 51124, 458740, "Left + Right (Flipped)", 1, 255, 255, 255, true);
 end
 
 SAO.Class["DEATHKNIGHT"] = {

--- a/classes/druid.lua
+++ b/classes/druid.lua
@@ -40,7 +40,7 @@ local function updateOneSAO(self, position, spellID, texture)
     if (texture == "") then
         self:DeactivateOverlay(spellID);
     else
-        self:ActivateOverlay(0, spellID, self.TexName[texture], position, 1, 255, 255, 255);
+        self:ActivateOverlay(0, spellID, self.TexName[texture], position, 1, 255, 255, 255, true);
     end
 end
 
@@ -137,11 +137,11 @@ end
 
 local function registerAuras(self)
     -- Track Eclipses with a custom CLEU function, so that eclipses can coexist with Omen of Clarity
-    -- self:RegisterAura("eclipse_lunar", 0, lunarSpellID, "eclipse_moon", "Left", 1, 255, 255, 255);
-    -- self:RegisterAura("eclipse_solar", 0, solarSpellID, "eclipse_sun", "Right (Flipped)", 1, 255, 255, 255);
+    -- self:RegisterAura("eclipse_lunar", 0, lunarSpellID, "eclipse_moon", "Left", 1, 255, 255, 255, true);
+    -- self:RegisterAura("eclipse_solar", 0, solarSpellID, "eclipse_sun", "Right (Flipped)", 1, 255, 255, 255, true);
 
     -- Track Omen of Clarity with a custom CLEU function, to be able to switch between feral and non-feral texture
-    -- self:RegisterAura("omen_of_clarity", 0, 16870, "natures_grace", "Left + Right (Flipped)", 1, 255, 255, 255);
+    -- self:RegisterAura("omen_of_clarity", 0, 16870, "natures_grace", "Left + Right (Flipped)", 1, 255, 255, 255, true);
 end
 
 SAO.Class["DRUID"] = {

--- a/classes/hunter.lua
+++ b/classes/hunter.lua
@@ -2,20 +2,20 @@ local AddonName, SAO = ...
 
 local function registerAuras(self)
     -- Improved Steady Shot, formerly Master Marksman
-    self:RegisterAura("improved_steady_shot", 0, 53220, "master_marksman", "Top", 1, 255, 255, 255);
+    self:RegisterAura("improved_steady_shot", 0, 53220, "master_marksman", "Top", 1, 255, 255, 255, true);
 
     -- Lock and Load, option 1: display something on top if there is at least one charge
     -- Advantage: easier to see
     -- Disadvantages: doesn't show the number of charges, may conflict with Improved Steady Shot
-    self:RegisterAura("lock_and_load_1", 1, 56453, "lock_and_load", "Top", 1, 255, 255, 255);
-    self:RegisterAura("lock_and_load_2", 2, 56453, "lock_and_load", "Top", 1, 255, 255, 255);
+    self:RegisterAura("lock_and_load_1", 1, 56453, "lock_and_load", "Top", 1, 255, 255, 255, true);
+    self:RegisterAura("lock_and_load_2", 2, 56453, "lock_and_load", "Top", 1, 255, 255, 255, true);
 
     -- Lock and Load, option 2: display the first charge on top-left and second charge on top-right
     -- Advantages: displays two charges, doesn't conflict with Improved Steady Shot
     -- Disadvantage: weird place to put them (smaller, away from the center)
-    -- self:RegisterAura("lock_and_load", 1, 56453, "lock_and_load", "TopLeft", 1, 255, 255, 255);
-    -- self:RegisterAura("lock_and_load_2left", 2, 56453, "lock_and_load", "TopLeft", 1, 255, 255, 255);
-    -- self:RegisterAura("lock_and_load_2right", 2, 56453, "lock_and_load", "TopRight", 1, 255, 255, 255);
+    -- self:RegisterAura("lock_and_load", 1, 56453, "lock_and_load", "TopLeft", 1, 255, 255, 255, true);
+    -- self:RegisterAura("lock_and_load_2left", 2, 56453, "lock_and_load", "TopLeft", 1, 255, 255, 255, true);
+    -- self:RegisterAura("lock_and_load_2right", 2, 56453, "lock_and_load", "TopRight", 1, 255, 255, 255, true);
 end
 
 SAO.Class["HUNTER"] = {

--- a/classes/mage.lua
+++ b/classes/mage.lua
@@ -47,7 +47,7 @@ end
 
 local function activateHeatingUp(self)
     -- Heating Up uses the Hot Streak texture, but scaled at 50%
-    self:ActivateOverlay(0, heatingUpSpellID, self.TexName["hot_streak"], "Left + Right (Flipped)", 0.5, 255, 255, 255);
+    self:ActivateOverlay(0, heatingUpSpellID, self.TexName["hot_streak"], "Left + Right (Flipped)", 0.5, 255, 255, 255, false);
 end
 
 local function deactivateHeatingUp(self)
@@ -156,19 +156,19 @@ end
 local function registerAuras(self)
     -- Fire Procs
     self:RegisterAura("impact", 0, 64343, "impact", "Top", 1, 255, 255, 255);
-    self:RegisterAura("hot_streak_full", 0, hotStreakSpellID, "hot_streak", "Left + Right (Flipped)", 1, 255, 255, 255);
-    --self:RegisterAura("hot_streak_half", 0, heatingUpSpellID, "hot_streak", "Left + Right (Flipped)", 0.5, 255, 255, 255);
+    self:RegisterAura("hot_streak_full", 0, hotStreakSpellID, "hot_streak", "Left + Right (Flipped)", 1, 255, 255, 255, true);
+    --self:RegisterAura("hot_streak_half", 0, heatingUpSpellID, "hot_streak", "Left + Right (Flipped)", 0.5, 255, 255, 255, false);
     -- Heating Up (spellID == 48107) doesn't exist in Wrath Classic, so we can't use the above aura
     -- Instead, we track Fire Blast, Fireball, Living Bomb and Scorch non-periodic critical strikes
     -- Please look at HotStreakHandler and customCLEU for more information
 
     -- Frost Procs
-    self:RegisterAura("fingers_of_frost_1", 1, 74396, 449489, "Left", 1, 255, 255, 255);
-    self:RegisterAura("fingers_of_frost_2", 2, 74396, 449489, "Left + Right (Flipped)", 1, 255, 255, 255);
-    self:RegisterAura("brain_freeze", 0, 57761, 449488, "Top", 1, 255, 255, 255);
+    self:RegisterAura("fingers_of_frost_1", 1, 74396, 449489, "Left", 1, 255, 255, 255, true);
+    self:RegisterAura("fingers_of_frost_2", 2, 74396, 449489, "Left + Right (Flipped)", 1, 255, 255, 255, true);
+    self:RegisterAura("brain_freeze", 0, 57761, 449488, "Top", 1, 255, 255, 255, true);
 
     -- Arcane Procs
-    self:RegisterAura("missile_barrage", 0, 44401, 449486, "Left + Right (Flipped)", 1, 255, 255, 255);
+    self:RegisterAura("missile_barrage", 0, 44401, 449486, "Left + Right (Flipped)", 1, 255, 255, 255, true);
 end
 
 SAO.Class["MAGE"] = {

--- a/classes/paladin.lua
+++ b/classes/paladin.lua
@@ -2,13 +2,13 @@ local AddonName, SAO = ...
 
 local function registerAuras(self)
     -- Art of War
-    self:RegisterAura("art_of_war", 0, 59578, 450913, "Left + Right (Flipped)", 1, 255, 255, 255);
+    self:RegisterAura("art_of_war", 0, 59578, 450913, "Left + Right (Flipped)", 1, 255, 255, 255, true);
 
     -- Infusion of Light, 1/2 talent points
-    self:RegisterAura("infusion_of_light_low", 0, 53672, "daybreak", "Left + Right (Flipped)", 1, 255, 255, 255);
+    self:RegisterAura("infusion_of_light_low", 0, 53672, "daybreak", "Left + Right (Flipped)", 1, 255, 255, 255, true);
 
     -- Infusion of Light, 2/2 talent points
-    self:RegisterAura("infusion_of_light_high", 0, 54149, "daybreak", "Left + Right (Flipped)", 1, 255, 255, 255);
+    self:RegisterAura("infusion_of_light_high", 0, 54149, "daybreak", "Left + Right (Flipped)", 1, 255, 255, 255, true);
 end
 
 SAO.Class["PALADIN"] = {

--- a/classes/priest.lua
+++ b/classes/priest.lua
@@ -1,22 +1,22 @@
 local AddonName, SAO = ...
 
 local function registerAuras(self)
-    self:RegisterAura("surge_of_light", 0, 33151, 450933, "Left + Right (Flipped)", 1, 255, 255, 255);
+    self:RegisterAura("surge_of_light", 0, 33151, 450933, "Left + Right (Flipped)", 1, 255, 255, 255, true);
 
     -- Serendipity with 1 talent point out of 3
---    self:RegisterAura("serendipity_low_1", 1, 63731, 469752, "Top", 0.25, 255, 255, 255);
---    self:RegisterAura("serendipity_low_2", 2, 63731, 469752, "Top", 0.5, 255, 255, 255);
-    self:RegisterAura("serendipity_low_3", 3, 63731, 469752, "Top", 1, 255, 255, 255);
+--    self:RegisterAura("serendipity_low_1", 1, 63731, 469752, "Top", 0.25, 255, 255, 255, true);
+--    self:RegisterAura("serendipity_low_2", 2, 63731, 469752, "Top", 0.5, 255, 255, 255, true);
+    self:RegisterAura("serendipity_low_3", 3, 63731, 469752, "Top", 1, 255, 255, 255, true);
 
     -- Serendipity with 2 talent points out of 3
---    self:RegisterAura("serendipity_medium_1", 1, 63735, 469752, "Top", 0.25, 255, 255, 255);
---    self:RegisterAura("serendipity_medium_2", 2, 63735, 469752, "Top", 0.5, 255, 255, 255);
-    self:RegisterAura("serendipity_medium_3", 3, 63735, 469752, "Top", 1, 255, 255, 255);
+--    self:RegisterAura("serendipity_medium_1", 1, 63735, 469752, "Top", 0.25, 255, 255, 255, true);
+--    self:RegisterAura("serendipity_medium_2", 2, 63735, 469752, "Top", 0.5, 255, 255, 255, true);
+    self:RegisterAura("serendipity_medium_3", 3, 63735, 469752, "Top", 1, 255, 255, 255, true);
 
     -- Serendipity with 3 talent points out of 3
---    self:RegisterAura("serendipity_high_1", 1, 63734, 469752, "Top", 0.25, 255, 255, 255);
---    self:RegisterAura("serendipity_high_2", 2, 63734, 469752, "Top", 0.5, 255, 255, 255);
-    self:RegisterAura("serendipity_high_3", 3, 63734, 469752, "Top", 1, 255, 255, 255);
+--    self:RegisterAura("serendipity_high_1", 1, 63734, 469752, "Top", 0.25, 255, 255, 255, true);
+--    self:RegisterAura("serendipity_high_2", 2, 63734, 469752, "Top", 0.5, 255, 255, 255, true);
+    self:RegisterAura("serendipity_high_3", 3, 63734, 469752, "Top", 1, 255, 255, 255, true);
 end
 
 SAO.Class["PRIEST"] = {

--- a/classes/shaman.lua
+++ b/classes/shaman.lua
@@ -2,15 +2,15 @@ local AddonName, SAO = ...
 
 local function registerAuras(self)
     -- Elemental Focus
-    self:RegisterAura("elemental_focus_1", 1, 16246, "echo_of_the_elements", "Left", 1, 255, 255, 255);
-    self:RegisterAura("elemental_focus_2", 2, 16246, "echo_of_the_elements", "Left + Right (Flipped)", 1, 255, 255, 255);
+    self:RegisterAura("elemental_focus_1", 1, 16246, "echo_of_the_elements", "Left", 1, 255, 255, 255, true);
+    self:RegisterAura("elemental_focus_2", 2, 16246, "echo_of_the_elements", "Left + Right (Flipped)", 1, 255, 255, 255, true);
 
     -- Maelstrom Weapon
-    self:RegisterAura("maelstrom_weapoon_1", 1, 53817, 1028136, "Top", 1, 255, 255, 255);
-    self:RegisterAura("maelstrom_weapoon_2", 2, 53817, 1028137, "Top", 1, 255, 255, 255);
-    self:RegisterAura("maelstrom_weapoon_3", 3, 53817, 1028138, "Top", 1, 255, 255, 255);
-    self:RegisterAura("maelstrom_weapoon_4", 4, 53817, 1028139, "Top", 1, 255, 255, 255);
-    self:RegisterAura("maelstrom_weapoon_5", 5, 53817, 450927, "Top", 1, 255, 255, 255);
+    self:RegisterAura("maelstrom_weapoon_1", 1, 53817, 1028136, "Top", 1, 255, 255, 255, false);
+    self:RegisterAura("maelstrom_weapoon_2", 2, 53817, 1028137, "Top", 1, 255, 255, 255, false);
+    self:RegisterAura("maelstrom_weapoon_3", 3, 53817, 1028138, "Top", 1, 255, 255, 255, false);
+    self:RegisterAura("maelstrom_weapoon_4", 4, 53817, 1028139, "Top", 1, 255, 255, 255, false);
+    self:RegisterAura("maelstrom_weapoon_5", 5, 53817, 450927, "Top", 1, 255, 255, 255, true);
 end
 
 SAO.Class["SHAMAN"] = {

--- a/classes/warlock.lua
+++ b/classes/warlock.lua
@@ -1,19 +1,19 @@
 local AddonName, SAO = ...
 
 local function registerMolenCore(self, baseName, spellID)
-    self:RegisterAura(baseName.."_1", 1, spellID, "molten_core", "Left", 1, 255, 255, 255);
-    self:RegisterAura(baseName.."_2", 2, spellID, "molten_core", "Left + Right (Flipped)", 1, 255, 255, 255);
-    self:RegisterAura(baseName.."_3", 3, spellID, "molten_core", "Left + Right (Flipped)", 1, 255, 255, 255);
-    self:RegisterAura(baseName.."_3_top", 3, spellID, "lock_and_load", "Top", 1, 255, 255, 255);
---    self:RegisterAura(baseName.."_3_top", 3, spellID, "impact", "Top", 1, 255, 255, 255);
+    self:RegisterAura(baseName.."_1", 1, spellID, "molten_core", "Left", 1, 255, 255, 255, true);
+    self:RegisterAura(baseName.."_2", 2, spellID, "molten_core", "Left + Right (Flipped)", 1, 255, 255, 255, true);
+    self:RegisterAura(baseName.."_3", 3, spellID, "molten_core", "Left + Right (Flipped)", 1, 255, 255, 255, true);
+    self:RegisterAura(baseName.."_3_top", 3, spellID, "lock_and_load", "Top", 1, 255, 255, 255, true);
+--    self:RegisterAura(baseName.."_3_top", 3, spellID, "impact", "Top", 1, 255, 255, 255, true);
 end
 
 local function registerAuras(self)
     -- Backlash
-    self:RegisterAura("backlash", 0, 34936, "backlash", "Top", 1, 255, 255, 255);
+    self:RegisterAura("backlash", 0, 34936, "backlash", "Top", 1, 255, 255, 255, true);
 
     -- Empowered Imp
-    self:RegisterAura("empowered_imp", 0, 47283, "imp_empowerment", "Left + Right (Flipped)", 1, 255, 255, 255);
+    self:RegisterAura("empowered_imp", 0, 47283, "imp_empowerment", "Left + Right (Flipped)", 1, 255, 255, 255, true);
 
     -- Molten Core
     registerMolenCore(self, "molten_core_low", 47383); -- 1/3 talent point
@@ -21,7 +21,7 @@ local function registerAuras(self)
     registerMolenCore(self, "molten_core_high", 71165); -- 3/3 talent points
 
     -- Nightfall / Shadow Trance
-    self:RegisterAura("nightfall", 0, 17941, "nightfall", "Left + Right (Flipped)", 1, 255, 255, 255);
+    self:RegisterAura("nightfall", 0, 17941, "nightfall", "Left + Right (Flipped)", 1, 255, 255, 255, true);
 end
 
 SAO.Class["WARLOCK"] = {

--- a/classes/warrior.lua
+++ b/classes/warrior.lua
@@ -1,9 +1,9 @@
 local AddonName, SAO = ...
 
 local function registerAuras(self)
-    self:RegisterAura("bloodsurge", 0, 46916, 449487, "Top", 1, 255, 255, 255);
-    self:RegisterAura("sudden_death", 0, 52437, 449493, "Left + Right (Flipped)", 1, 255, 255, 255);
-    self:RegisterAura("sword_and_board", 0, 50227, 449494, "Left + Right (Flipped)", 1, 255, 255, 255);
+    self:RegisterAura("bloodsurge", 0, 46916, 449487, "Top", 1, 255, 255, 255, true);
+    self:RegisterAura("sudden_death", 0, 52437, 449493, "Left + Right (Flipped)", 1, 255, 255, 255, true);
+    self:RegisterAura("sword_and_board", 0, 50227, 449494, "Left + Right (Flipped)", 1, 255, 255, 255, true);
 end
 
 SAO.Class["WARRIOR"] = {


### PR DESCRIPTION
Implementation of #8
- new parameter when activating a SAO, to tell if it should pulse
- this param is almost always true, which is equivalent to the previous behaviour
- this param is false in the following cases, which act as a "soon" indicator:
  - Mage's Heating Up
  - Shaman's Maelstrom Weapon between 1 and 4 stacks (max stacks = 5)