### PR TITLE
Feature #10 Out of Combat Visibility

### DIFF
--- a/SpellActivationOverlay.lua
+++ b/SpellActivationOverlay.lua
@@ -28,6 +28,8 @@ function SpellActivationOverlay_OnLoad(self)
 	self:RegisterEvent("PLAYER_ENTERING_WORLD");
 	self:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED");
 	self:RegisterEvent("UPDATE_SHAPESHIFT_FORM");
+	self:RegisterEvent("PLAYER_REGEN_ENABLED");
+	self:RegisterEvent("PLAYER_REGEN_DISABLED");
 	
 	self:SetSize(longSide, longSide)
 end
@@ -50,7 +52,13 @@ function SpellActivationOverlay_OnEvent(self, event, ...)
 		else
 			SpellActivationOverlay_HideAllOverlays(self);
 		end
-	else]]if ( event ) then
+	end]]
+	if ( event == "PLAYER_REGEN_DISABLED" ) then
+		self.combatAnimIn:Play();
+	elseif ( event == "PLAYER_REGEN_ENABLED" ) then
+		self.combatAnimOut:Play();
+	end
+	if ( event ) then
 		SAO:OnEvent(event, ...);
 	end
 end
@@ -221,4 +229,14 @@ function SpellActivationOverlayTexture_OnFadeOutFinished(anim)
 	overlay:Hide();
 	tDeleteItem(overlayParent.overlaysInUse[overlay.spellID], overlay)
 	tinsert(overlayParent.unusedOverlays, overlay);
+end
+
+function SpellActivationOverlayFrame_OnFadeInFinished(anim)
+	local frame = anim:GetParent();
+	frame:SetAlpha(1);
+end
+
+function SpellActivationOverlayFrame_OnFadeOutFinished(anim)
+	local frame = anim:GetParent();
+	frame:SetAlpha(0.5);
 end

--- a/SpellActivationOverlay.xml
+++ b/SpellActivationOverlay.xml
@@ -31,11 +31,25 @@
 			<OnShow function="SpellActivationOverlayTexture_OnShow"/>
 		</Scripts>
 	</Frame>
-	<Frame name="SpellActivationOverlayFrame" parent="UIParent">
+	<Frame name="SpellActivationOverlayFrame" parent="UIParent" alpha="0.5">
 		<Size x="256" y="256"/>
 		<Anchors>
 			<Anchor point="CENTER"/>
 		</Anchors>
+		<Animations>
+			<AnimationGroup name="$enteringCombatAnim" parentKey="combatAnimIn">
+				<Alpha fromAlpha="0.5" toAlpha="1" duration="0.1"/>
+				<Scripts>
+					<OnFinished function="SpellActivationOverlayFrame_OnFadeInFinished"/>
+				</Scripts>
+			</AnimationGroup>
+			<AnimationGroup name="$leavingCombatAnim" parentKey="combatAnimOut">
+				<Alpha fromAlpha="1" toAlpha="0.5" duration="0.2"/>
+				<Scripts>
+					<OnFinished function="SpellActivationOverlayFrame_OnFadeOutFinished"/>
+				</Scripts>
+			</AnimationGroup>
+		</Animations>
 		<Scripts>
 			<OnLoad function="SpellActivationOverlay_OnLoad"/>
 			<OnEvent function="SpellActivationOverlay_OnEvent"/>

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 ## SpellActivationOverlay Changelog
 
+#### v0.4.2-beta (2022-08-xx)
+
+- Alpha is reduced by 50% when out of combat
+
 #### v0.4.1-beta (2022-08-05)
 
 - New SAO: Paladin's Infusion of Light


### PR DESCRIPTION
Implements #10
- by default, alpha is 50%
- when entering combat, alpha quickly rises to 100%
- when leaving combat, alpha dims back to 50%

Because SAOs usually proc in combat, the default 50% alpha is unnoticeable for most classes.