### PR TITLE
Fix #25 Hidden SAOs on ReloadUI

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,8 @@
 #### v0.4.2-beta (2022-08-xx)
 
 - Alpha is reduced by 50% when out of combat
+- SAOs are shown uplon login if player already has the corresponding buffs
+- Currently, this includes all SAOs but Heating Up, which is not a buff
 
 #### v0.4.1-beta (2022-08-05)
 

--- a/classes/common.lua
+++ b/classes/common.lua
@@ -25,6 +25,8 @@ SAO.ActiveOverlays = {}
 -- Arguments simply need to copy Retail's SPELL_ACTIVATION_OVERLAY_SHOW event arguments
 function SAO.RegisterAura(self, name, stacks, spellID, texture, positions, scale, r, g, b, autoPulse)
     local aura = { name, stacks, spellID, self.TexName[texture], positions, scale, r, g, b, autoPulse }
+
+    -- Register aura in the spell list, sorted by spell ID and by stack count
     self.RegisteredAurasByName[name] = aura;
     if self.RegisteredAurasBySpellID[spellID] then
         if self.RegisteredAurasBySpellID[spellID][stacks] then
@@ -34,6 +36,12 @@ function SAO.RegisterAura(self, name, stacks, spellID, texture, positions, scale
         end
     else
         self.RegisteredAurasBySpellID[spellID] = { [stacks] = { aura } }
+    end
+
+    -- Apply aura immediately, if found
+    local exists, _, count = select(3, self:FindPlayerAuraByID(spellID));
+    if (exists and (stacks == 0 or stacks == count)) then
+        self:ActivateOverlay(count, select(3,unpack(aura)));
     end
 end
 


### PR DESCRIPTION
Fixes #25

The chosen solution was to test if an aura is present immediately after registration.

The only thing to be careful is that the number of stacks of the current buff must match with the number of stacks of the registered aura.