### PR TITLE
Fix #36 Heating Up is lost on death

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 - Alpha is reduced by 50% when out of combat
 - SAOs are shown uplon login if player already has the corresponding buffs
 - Currently, this includes all SAOs but Heating Up, which is not a buff
+- Mage's Heating Up is no longer lost on death
 
 #### v0.4.1-beta (2022-08-05)
 

--- a/classes/mage.lua
+++ b/classes/mage.lua
@@ -57,15 +57,17 @@ end
 local function customCLEU(self, ...)
     local timestamp, event, _, sourceGUID, sourceName, sourceFlags, sourceRaidFlags, destGUID, destName, destFlags, destRaidFlags = CombatLogGetCurrentEventInfo() -- For all events
 
-    -- Special case: if player dies, we assume the "Heating Up" virtual buff is lost
-    if (event == "UNIT_DIED" and destGUID == UnitGUID("player")) then
-        if (HotStreakHandler.state == 'heating_up') then
-            deactivateHeatingUp(self);
-        end
-        HotStreakHandler.state = 'cold';
-
-        return;
-    end
+    -- Special case: if player dies, we assumed the "Heating Up" virtual buff was lost
+    -- However, data suggest that Heating Up is *not* lost on death, invalidating the code below
+    -- The code is kept commented instead of removed, because Blizzard may change this behaviour
+    --if (event == "UNIT_DIED" and destGUID == UnitGUID("player")) then
+    --    if (HotStreakHandler.state == 'heating_up') then
+    --        deactivateHeatingUp(self);
+    --    end
+    --    HotStreakHandler.state = 'cold';
+    --
+    --    return;
+    --end
 
     -- Accept only certain events, and only when done by the player
     if (event ~= "SPELL_DAMAGE" and event ~= "SPELL_AURA_APPLIED" and event ~= "SPELL_AURA_REMOVED") then return end


### PR DESCRIPTION
Fixes #36

The code which tracked `UNIT_DIED` is simply commented.

The code is kept in case observed behaviour is a bug that Blizzard decides to fix in the future, in which case we'll simply have to un-comment this code.