### PR TITLE
Glowing Action Buttons (GABs)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -125,7 +125,11 @@
         "ActionButton_HideOverlayGlow",
         "IsUsableSpell",
         "GetSpellCooldown",
-        "OverrideActionBar"
+        "OverrideActionBar",
+        "GetNumSpellTabs",
+        "GetSpellTabInfo",
+        "GetSpellBookItemName",
+        "BOOKTYPE_SPELL"
     ],
     "workbench.colorCustomizations": {
         "activityBar.activeBackground": "#4f71dc",
@@ -144,7 +148,8 @@
         "titleBar.activeBackground": "#2951cf",
         "titleBar.activeForeground": "#e7e7e7",
         "titleBar.inactiveBackground": "#2951cf99",
-        "titleBar.inactiveForeground": "#e7e7e799"
+        "titleBar.inactiveForeground": "#e7e7e799",
+        "commandCenter.border": "#e7e7e799"
     },
     "peacock.color": "#2951cf"
 }

--- a/SpellActivationOverlay.lua
+++ b/SpellActivationOverlay.lua
@@ -33,6 +33,7 @@ function SpellActivationOverlay_OnLoad(self)
 --	self:RegisterEvent("SPELL_ACTIVATION_OVERLAY_HIDE");
 --	self:RegisterUnitEvent("UNIT_AURA", "player");
 	self:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED");
+	self:RegisterEvent("SPELL_UPDATE_USABLE");
 	self:RegisterEvent("PLAYER_REGEN_ENABLED");
 	self:RegisterEvent("PLAYER_REGEN_DISABLED");
 	self:RegisterEvent("SPELLS_CHANGED");

--- a/SpellActivationOverlay.lua
+++ b/SpellActivationOverlay.lua
@@ -35,6 +35,7 @@ function SpellActivationOverlay_OnLoad(self)
 	self:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED");
 	self:RegisterEvent("PLAYER_REGEN_ENABLED");
 	self:RegisterEvent("PLAYER_REGEN_DISABLED");
+	self:RegisterEvent("LEARNED_SPELL_IN_TAB");
 	
 	self:SetSize(longSide, longSide)
 end

--- a/SpellActivationOverlay.lua
+++ b/SpellActivationOverlay.lua
@@ -35,6 +35,7 @@ function SpellActivationOverlay_OnLoad(self)
 	self:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED");
 	self:RegisterEvent("PLAYER_REGEN_ENABLED");
 	self:RegisterEvent("PLAYER_REGEN_DISABLED");
+	self:RegisterEvent("SPELLS_CHANGED");
 	self:RegisterEvent("LEARNED_SPELL_IN_TAB");
 	
 	self:SetSize(longSide, longSide)

--- a/SpellActivationOverlay.toc
+++ b/SpellActivationOverlay.toc
@@ -8,6 +8,7 @@
 # were created by Blizzard Entertainment, Inc.
 
 aura.lua
+counter.lua
 events.lua
 glow.lua
 overlay.lua

--- a/SpellActivationOverlay.toc
+++ b/SpellActivationOverlay.toc
@@ -11,6 +11,7 @@ aura.lua
 events.lua
 glow.lua
 overlay.lua
+spell.lua
 util.lua
 
 textures\texname.lua

--- a/_curse/release_notes.html
+++ b/_curse/release_notes.html
@@ -1,6 +1,7 @@
 <h3>Spell Activation Overlay</h3>
 <p>This WoW Classic addon mimics Spell Activation Overlays, formerly known as Spell Alerts, which were introduced in Cataclysm.</p>
 <p>For example, Frost Death Knights can have procs for Rime and Killing Machine, while Enhancement Shamans have stacks of Maelstrom Weapon.</p>
+<p>This addon also makes relevant buttons glow. For example, a Fire mage triggering Hot Streak will have a glowing Pyroblast button.</p>
 <p>There is nothing to configure. Just install the addon and enjoy your procs!</p>
 <p>&nbsp;</p>
 <h4><strong>Death Knight</strong>: Killing Machine, Rime</h4>
@@ -78,6 +79,5 @@
 </p>
 <p>&nbsp;</p>
 <h4>Contribution</h4>
-<p>The addon is very new.</p>
-<p>Classes are implemented one after the other, and I don&rsquo;t pretend to know all effects of all classes anyway.</p>
-<p>If you wish to contribute, please file an Issue or send a Pull Request to <a href="https://github.com/ennvina/spellactivationoverlay">the github repository</a>.</p>
+<p>If you wish to contribute, please come by and visit <a href="https://discord.gg/VrDkvDV4">the Discord server</a>.</p>
+<p>You can also file an Issue or send a Pull Request to <a href="https://github.com/ennvina/spellactivationoverlay">the github repository</a>.</p>

--- a/_curse/release_notes.html
+++ b/_curse/release_notes.html
@@ -4,7 +4,7 @@
 <p>This addon also makes relevant buttons glow. For example, a Fire mage triggering Hot Streak will have a glowing Pyroblast button.</p>
 <p>There is nothing to configure. Just install the addon and enjoy your procs!</p>
 <p>&nbsp;</p>
-<h4><strong>Death Knight</strong>: Killing Machine, Rime</h4>
+<h4><strong>Death Knight</strong>: Killing Machine, Rime, Rune Strike (glowing button only)</h4>
 <p><img src="https://cdn.discordapp.com/attachments/967369772595576902/1005135196145852517/killing-machine-rime.gif" alt="Killing Machine + Rime" width="256" height="256" /></p>
 <p>&nbsp;</p>
 <h4><strong>Druid</strong>: Omen of Clarity, Omen of Clarity (Feral), Eclipse (Lunar), Eclipse (Solar)</h4>
@@ -18,7 +18,7 @@
 <img src="https://cdn.discordapp.com/attachments/630388545697349632/1003394587081052191/solar-eclipse.gif" alt="Eclipse (Solar) and Omen of Clarity" width="256" height="256" />
 </p>
 <p>&nbsp;</p>
-<h4><strong>Hunter</strong>: Improved Steady Shot</h4>
+<h4><strong>Hunter</strong>: Improved Steady Shot, Lock and Load, Counterattack (glowing button only)</h4>
 <p>
 <img src="https://cdn.discordapp.com/attachments/630388472926175262/1003232574304428032/improved-steady-shot.png" alt="Improved Steady Shot" width="256" height="256" />
 &nbsp;
@@ -69,7 +69,7 @@
 <img src="https://cdn.discordapp.com/attachments/630388441678348308/1002722133656485979/molten-core-2.gif" alt="Molten Core" width="256" height="256" />
 </p>
 <p>&nbsp;</p>
-<h4><strong>Warrior</strong>: Bloodsurge, Sudden Death, Sword and Board</h4>
+<h4><strong>Warrior</strong>: Bloodsurge, Sudden Death, Sword and Board, Overpower (glowing button only), Revenge (glowing button only)</h4>
 <p>
 <img src="https://cdn.discordapp.com/attachments/630388398640594955/1002541679380811796/bloodsurge.png" alt="Bloodsurge" width="256" height="256" />
 &nbsp;

--- a/aura.lua
+++ b/aura.lua
@@ -15,9 +15,13 @@ SAO.RegisteredAurasBySpellID = {}
 
 -- List of spell IDs that should be tracked to glow action buttons
 -- The spell ID may differ from the spell ID for the corresponding aura
--- key = glowID (= spell ID of the glowing spell), value = true
+-- key = glowID (= spell ID/name of the glowing spell), value = true
 -- The lists should be setup at start, based on the player class
-SAO.RegisteredGlowIDs = {}
+SAO.RegisteredGlowSpellIDs = {}
+
+-- List of spell names that should be tracked to glow action buttons
+-- This helps to fill RegisteredGlowSpellIDs e.g., when a spell is learned
+SAO.RegisteredGlowSpellNames = {}
 
 -- Register a new aura
 -- All arguments before autoPulse simply need to copy Retail's SPELL_ACTIVATION_OVERLAY_SHOW event arguments
@@ -39,7 +43,17 @@ function SAO.RegisterAura(self, name, stacks, spellID, texture, positions, scale
     -- Register the glow IDs
     -- The same glow ID may be registered by different auras, but it's okay
     for _, glowID in ipairs(glowIDs or {}) do
-        self.RegisteredGlowIDs[glowID] = true;
+        if (type(glowID) == "number") then
+            self.RegisteredGlowSpellIDs[glowID] = true;
+        elseif (type(glowID) == "string") then
+            if (not SAO.RegisteredGlowSpellNames[glowID]) then
+                SAO.RegisteredGlowSpellNames[glowID] = true;
+                local glowSpellIDs = self:GetSpellIDsByName(glowID);
+                for _, glowSpellID in ipairs(glowSpellIDs) do
+                    self.RegisteredGlowSpellIDs[glowSpellID] = true;
+                end
+            end
+        end
     end
 
     -- Apply aura immediately, if found

--- a/aura.lua
+++ b/aura.lua
@@ -13,16 +13,6 @@ local AddonName, SAO = ...
 SAO.RegisteredAurasByName = {}
 SAO.RegisteredAurasBySpellID = {}
 
--- List of spell IDs that should be tracked to glow action buttons
--- The spell ID may differ from the spell ID for the corresponding aura
--- key = glowID (= spell ID/name of the glowing spell), value = true
--- The lists should be setup at start, based on the player class
-SAO.RegisteredGlowSpellIDs = {}
-
--- List of spell names that should be tracked to glow action buttons
--- This helps to fill RegisteredGlowSpellIDs e.g., when a spell is learned
-SAO.RegisteredGlowSpellNames = {}
-
 -- Register a new aura
 -- If texture is nil, no Spell Activation Overlay (SAO) is triggered; subsequent params are ignored until glowIDs
 -- If glowIDs is nil or empty, no Glowing Action Button (GAB) is triggered
@@ -44,19 +34,7 @@ function SAO.RegisterAura(self, name, stacks, spellID, texture, positions, scale
 
     -- Register the glow IDs
     -- The same glow ID may be registered by different auras, but it's okay
-    for _, glowID in ipairs(glowIDs or {}) do
-        if (type(glowID) == "number") then
-            self.RegisteredGlowSpellIDs[glowID] = true;
-        elseif (type(glowID) == "string") then
-            if (not SAO.RegisteredGlowSpellNames[glowID]) then
-                SAO.RegisteredGlowSpellNames[glowID] = true;
-                local glowSpellIDs = self:GetSpellIDsByName(glowID);
-                for _, glowSpellID in ipairs(glowSpellIDs) do
-                    self.RegisteredGlowSpellIDs[glowSpellID] = true;
-                end
-            end
-        end
-    end
+    self:RegisterGlowIDs(glowIDs);
 
     -- Apply aura immediately, if found
     local exists, _, count = select(3, self:FindPlayerAuraByID(spellID));

--- a/aura.lua
+++ b/aura.lua
@@ -24,9 +24,11 @@ SAO.RegisteredGlowSpellIDs = {}
 SAO.RegisteredGlowSpellNames = {}
 
 -- Register a new aura
--- All arguments before autoPulse simply need to copy Retail's SPELL_ACTIVATION_OVERLAY_SHOW event arguments
+-- If texture is nil, no Spell Activation Overlay (SAO) is triggered; subsequent params are ignored until glowIDs
+-- If glowIDs is nil or empty, no Glowing Action Button (GAB) is triggered
+-- All SAO arguments (between spellID and b, included) mimic Retail's SPELL_ACTIVATION_OVERLAY_SHOW event arguments
 function SAO.RegisterAura(self, name, stacks, spellID, texture, positions, scale, r, g, b, autoPulse, glowIDs)
-    local aura = { name, stacks, spellID, self.TexName[texture], positions, scale, r, g, b, autoPulse, glowIDs }
+    local aura = { name, stacks, spellID, texture and self.TexName[texture], positions, scale, r, g, b, autoPulse, glowIDs }
 
     -- Register aura in the spell list, sorted by spell ID and by stack count
     self.RegisteredAurasByName[name] = aura;

--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@ Support for Glowing Action Buttons (GABs), making some actions glow, namely:
 - Warlock's Shadow Bolt and Incinerate buttons glow during Backlash
 - Warlock's Incinerate and Soul Fire buttons glow during Molten Core
 - Warrior's Overpower button glows after the enemy dodges, if in Battle Stance
+- Warrior's Revenge button glows after parry/dodge/block in Defensive Stance
 - Warrior's Execute button glows during Sudden Death
 - Warrior's Slam button glows during Bloodsurge
 - Warrior's Shield Slam button glows during Sword and Board

--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,7 @@
 SpellActivationOverlay now has a Discord server!
 Make sure to check it out at https://discord.gg/VrDkvDV4
 
-Support for Glowing Action Buttons (GABs), making relevant actions glow
+Support for Glowing Action Buttons (GABs), making some actions glow, namely:
 - Mage's Arcane Missiles button glows during Missile Barrage
 - Mage's Pyroblast button glows during Hot Streak
 - Mage's Fire Blast button glows during Impact
@@ -14,9 +14,10 @@ Support for Glowing Action Buttons (GABs), making relevant actions glow
 - Paladin's Flash of Light and Exorcism buttons glow during The Art of War
 - Priest's Smite and Flash Heal buttons glow during Surge of Light
 - Priest's Greater Heal and Prayer of Healing glow at 3 stacks of Serendipity
-- Rogue's Riposte button glows after parrying an attack
+- Rogue's Riposte button glows after parrying an attack, unless on cooldown
 - Warlock's Shadow Bolt button glows during Nightfall, a.k.a. Shadow Trance
 - Warlock's Shadow Bolt and Incinerate buttons glow during Backlash
+- Warlock's Incinerate and Soul Fire buttons glow during Molten Core
 
 - New SAO: Rogue's Riposte
 - SAOs should now always show up on ReloadUI

--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@ Support for Glowing Action Buttons (GABs), making some actions glow, namely:
 - Warlock's Shadow Bolt button glows during Nightfall, a.k.a. Shadow Trance
 - Warlock's Shadow Bolt and Incinerate buttons glow during Backlash
 - Warlock's Incinerate and Soul Fire buttons glow during Molten Core
+- Warrior's Shield Slam button glows during Sword and Board
 
 - New SAO: Rogue's Riposte
 - SAOs should now always show up on ReloadUI

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ Make sure to check it out at https://discord.gg/VrDkvDV4
 Support for Glowing Action Buttons (GABs), making some actions glow, namely:
 - Death Knight's Rune Strike button glows after parrying or dodging an attack
 - Death Knight's Howling Blast button glows during Rime
+- DK's Icy Touch/Frost Strike/Howling Blast buttons glow during Killing Machine
 - Druid's Wrath button glows during Solar Eclipse
 - Druid's Starfire button glows during Lunar Eclipse
 - Hunter's Counterattack button glows after parrying an attack, unless on CD

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ Make sure to check it out at https://discord.gg/VrDkvDV4
 Support for Glowing Action Buttons (GABs), making relevant actions glow
 - Mage's Arcane Missiles button glows during Missile Barrage
 - Mage's Pyroblast button glows during Hot Streak
+- Mage's Fire Blast button glows during Impact
 - Mage's Fireball and Frostfire Bolt buttons glow during Brain Freeze
 - Rogue's Riposte button glows after parrying an attack
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ Make sure to check it out at https://discord.gg/VrDkvDV4
 
 Support for Glowing Action Buttons (GABs), making some actions glow, namely:
 - Hunter's Aimed/Arcane/Chimera Shot buttons glow during Improved Steady Shot
+- Hunter's Arcane/Explosive Shot buttons glow during Lock and Load
 - Mage's Arcane Missiles button glows during Missile Barrage
 - Mage's Pyroblast button glows during Hot Streak
 - Mage's Fire Blast button glows during Impact

--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,7 @@ Support for Glowing Action Buttons (GABs), making some actions glow, namely:
 - Warlock's Shadow Bolt button glows during Nightfall, a.k.a. Shadow Trance
 - Warlock's Shadow Bolt and Incinerate buttons glow during Backlash
 - Warlock's Incinerate and Soul Fire buttons glow during Molten Core
+- Warrior's Overpower button glows after the enemy dodges, if in Battle Stance
 - Warrior's Execute button glows during Sudden Death
 - Warrior's Slam button glows during Bloodsurge
 - Warrior's Shield Slam button glows during Sword and Board

--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@ Support for Glowing Action Buttons (GABs), making relevant actions glow
 - Priest's Smite and Flash Heal buttons glow during Surge of Light
 - Priest's Greater Heal and Prayer of Healing glow at 3 stacks of Serendipity
 - Rogue's Riposte button glows after parrying an attack
+- Warlock's Shadow Bolt button glows during Nightfall, a.k.a. Shadow Trance
 - Warlock's Shadow Bolt and Incinerate buttons glow during Backlash
 
 - New SAO: Rogue's Riposte

--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@ Support for Glowing Action Buttons (GABs), making some actions glow, namely:
 - Warlock's Shadow Bolt button glows during Nightfall, a.k.a. Shadow Trance
 - Warlock's Shadow Bolt and Incinerate buttons glow during Backlash
 - Warlock's Incinerate and Soul Fire buttons glow during Molten Core
+- Warrior's Execute button glows during Sudden Death
 - Warrior's Slam button glows during Bloodsurge
 - Warrior's Shield Slam button glows during Sword and Board
 

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ Support for Glowing Action Buttons (GABs), making relevant actions glow
 - Mage's Pyroblast button glows during Hot Streak
 - Mage's Fire Blast button glows during Impact
 - Mage's Fireball and Frostfire Bolt buttons glow during Brain Freeze
+- Paladin's Flash of Light and Holy Light buttons glow during Infusion of Light
 - Rogue's Riposte button glows after parrying an attack
 
 - New SAO: Rogue's Riposte

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ SpellActivationOverlay now has a Discord server!
 Make sure to check it out at https://discord.gg/VrDkvDV4
 
 Support for Glowing Action Buttons (GABs), making some actions glow, namely:
+- Hunter's Aimed/Arcane/Chimera Shot buttons glow during Improved Steady Shot
 - Mage's Arcane Missiles button glows during Missile Barrage
 - Mage's Pyroblast button glows during Hot Streak
 - Mage's Fire Blast button glows during Impact

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@ Support for Glowing Action Buttons (GABs), making relevant actions glow
 - Paladin's Flash of Light and Holy Light buttons glow during Infusion of Light
 - Paladin's Flash of Light and Exorcism buttons glow during The Art of War
 - Priest's Smite and Flash Heal buttons glow during Surge of Light
+- Priest's Greater Heal and Prayer of Healing glow at 3 stacks of Serendipity
 - Rogue's Riposte button glows after parrying an attack
 
 - New SAO: Rogue's Riposte

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ SpellActivationOverlay now has a Discord server!
 Make sure to check it out at https://discord.gg/VrDkvDV4
 
 Support for Glowing Action Buttons (GABs), making some actions glow, namely:
+- Death Knight's Rune Strike button glows after parrying or dodging an attack
 - Druid's Wrath button glows during Solar Eclipse
 - Druid's Starfire button glows during Lunar Eclipse
 - Hunter's Counterattack button glows after parrying an attack, unless on CD

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@ Support for Glowing Action Buttons (GABs), making relevant actions glow
 - Mage's Fireball and Frostfire Bolt buttons glow during Brain Freeze
 - Paladin's Flash of Light and Holy Light buttons glow during Infusion of Light
 - Paladin's Flash of Light and Exorcism buttons glow during The Art of War
+- Priest's Smite and Flash Heal buttons glow during Surge of Light
 - Rogue's Riposte button glows after parrying an attack
 
 - New SAO: Rogue's Riposte

--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@ Support for Glowing Action Buttons (GABs), making some actions glow, namely:
 - Warlock's Shadow Bolt button glows during Nightfall, a.k.a. Shadow Trance
 - Warlock's Shadow Bolt and Incinerate buttons glow during Backlash
 - Warlock's Incinerate and Soul Fire buttons glow during Molten Core
+- Warrior's Slam button glows during Bloodsurge
 - Warrior's Shield Slam button glows during Sword and Board
 
 - New SAO: Rogue's Riposte

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@ Support for Glowing Action Buttons (GABs), making relevant actions glow
 - Mage's Fire Blast button glows during Impact
 - Mage's Fireball and Frostfire Bolt buttons glow during Brain Freeze
 - Paladin's Flash of Light and Holy Light buttons glow during Infusion of Light
+- Paladin's Flash of Light and Exorcism buttons glow during The Art of War
 - Rogue's Riposte button glows after parrying an attack
 
 - New SAO: Rogue's Riposte

--- a/changelog.md
+++ b/changelog.md
@@ -2,9 +2,17 @@
 
 #### v0.5.0-beta (2022-08-xx)
 
+SpellActivationOverlay now has a Discord server!
+Make sure to check it out at https://discord.gg/VrDkvDV4
+
+Support for Glowing Action Buttons (GABs), making relevant actions glow
+- Mage's Arcane Missiles button glows during Missile Barrage
+- Mage's Pyroblast button glows during Hot Streak
+- Mage's Fireball and Frostfire Bolt buttons glow during Brain Freeze
+- Rogue's Riposte button glows after parrying an attack
+
 - New SAO: Rogue's Riposte
 - SAOs should now always show up on ReloadUI
-- Support for Glowing Action Buttons (GABs), currently for Riposte only
 
 #### v0.4.2-beta (2022-08-05)
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ SpellActivationOverlay now has a Discord server!
 Make sure to check it out at https://discord.gg/VrDkvDV4
 
 Support for Glowing Action Buttons (GABs), making some actions glow, namely:
+- Druid's Wrath button glows during Solar Eclipse
+- Druid's Starfire button glows during Lunar Eclipse
 - Hunter's Counterattack button glows after parrying an attack, unless on CD
 - Hunter's Aimed/Arcane/Chimera Shot buttons glow during Improved Steady Shot
 - Hunter's Arcane/Explosive Shot buttons glow during Lock and Load

--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@ Support for Glowing Action Buttons (GABs), making relevant actions glow
 - Priest's Smite and Flash Heal buttons glow during Surge of Light
 - Priest's Greater Heal and Prayer of Healing glow at 3 stacks of Serendipity
 - Rogue's Riposte button glows after parrying an attack
+- Warlock's Shadow Bolt and Incinerate buttons glow during Backlash
 
 - New SAO: Rogue's Riposte
 - SAOs should now always show up on ReloadUI

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ Make sure to check it out at https://discord.gg/VrDkvDV4
 
 Support for Glowing Action Buttons (GABs), making some actions glow, namely:
 - Death Knight's Rune Strike button glows after parrying or dodging an attack
+- Death Knight's Howling Blast button glows during Rime
 - Druid's Wrath button glows during Solar Eclipse
 - Druid's Starfire button glows during Lunar Eclipse
 - Hunter's Counterattack button glows after parrying an attack, unless on CD

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ SpellActivationOverlay now has a Discord server!
 Make sure to check it out at https://discord.gg/VrDkvDV4
 
 Support for Glowing Action Buttons (GABs), making some actions glow, namely:
+- Hunter's Counterattack button glows after parrying an attack, unless on CD
 - Hunter's Aimed/Arcane/Chimera Shot buttons glow during Improved Steady Shot
 - Hunter's Arcane/Explosive Shot buttons glow during Lock and Load
 - Mage's Arcane Missiles button glows during Missile Barrage

--- a/classes/deathknight.lua
+++ b/classes/deathknight.lua
@@ -3,6 +3,10 @@ local AddonName, SAO = ...
 local function registerClass(self)
     self:RegisterAura("rime", 0, 59052, "rime", "Top", 1, 255, 255, 255, true);
     self:RegisterAura("killing_machine", 0, 51124, "killing_machine", "Left + Right (Flipped)", 1, 255, 255, 255, true);
+
+    local runeStrike = 56815;
+    self:RegisterAura("rune_strike", 0, runeStrike, nil, "", 0, 0, 0, 0, false, { runeStrike });
+    self:RegisterCounter("rune_strike"); -- Must match name from above call
 end
 
 SAO.Class["DEATHKNIGHT"] = {

--- a/classes/deathknight.lua
+++ b/classes/deathknight.lua
@@ -1,8 +1,11 @@
 local AddonName, SAO = ...
 
 local function registerClass(self)
+    local icyTouch = GetSpellInfo(45477);
+    local frostStrike = GetSpellInfo(49143);
     local howlingBlast = GetSpellInfo(49184);
     self:RegisterAura("rime", 0, 59052, "rime", "Top", 1, 255, 255, 255, true, { howlingBlast });
+    self:RegisterAura("killing_machine", 0, 51124, "killing_machine", "Left + Right (Flipped)", 1, 255, 255, 255, true, { icyTouch, frostStrike, howlingBlast });
 
     local runeStrike = 56815;
     self:RegisterAura("rune_strike", 0, runeStrike, nil, "", 0, 0, 0, 0, false, { runeStrike });

--- a/classes/deathknight.lua
+++ b/classes/deathknight.lua
@@ -1,8 +1,8 @@
 local AddonName, SAO = ...
 
 local function registerClass(self)
-    self:RegisterAura("rime", 0, 59052, "rime", "Top", 1, 255, 255, 255, true);
-    self:RegisterAura("killing_machine", 0, 51124, "killing_machine", "Left + Right (Flipped)", 1, 255, 255, 255, true);
+    local howlingBlast = GetSpellInfo(49184);
+    self:RegisterAura("rime", 0, 59052, "rime", "Top", 1, 255, 255, 255, true, { howlingBlast });
 
     local runeStrike = 56815;
     self:RegisterAura("rune_strike", 0, runeStrike, nil, "", 0, 0, 0, 0, false, { runeStrike });

--- a/classes/druid.lua
+++ b/classes/druid.lua
@@ -12,6 +12,9 @@ local solarCache = false;
 local leftTexture = '';
 local rightTexture = '';
 
+local glowingWrath = false;
+local glowingStarfire = false;
+
 -- Assign fake spell IDs for left and right textures, and make sure they are different
 -- If we used the 'real' spell IDs instead of fake IDs, we would see weird transitions
 -- If spell IDs were identical, hiding the left or right SAO could also hide the other
@@ -83,12 +86,37 @@ local function updateSAOs(self)
     end
 end
 
+local function updateGABs(self)
+    if (lunarCache ~= glowingStarfire) then
+        local starfireSpellID = 2912;
+        if (lunarCache) then
+            self:AddGlow(starfireSpellID, { (GetSpellInfo(starfireSpellID)) });
+            glowingStarfire = true;
+        else
+            self:RemoveGlow(starfireSpellID);
+            glowingStarfire = false;
+        end
+    end
+
+    if (solarCache ~= glowingWrath) then
+        local wrathSpellID = 5176;
+        if (solarCache) then
+            self:AddGlow(wrathSpellID, { (GetSpellInfo(wrathSpellID)) });
+            glowingWrath = true;
+        else
+            self:RemoveGlow(wrathSpellID);
+            glowingWrath = false;
+        end
+    end
+end
+
 local function customLoad(self)
     feralCache = isFeral(self);
     clarityCache = hasClarity(self);
     lunarCache = hasLunar(self);
     solarCache = hasSolar(self);
     updateSAOs(self);
+    updateGABs(self);
 end
 
 local function updateShapeshift(self)
@@ -115,9 +143,11 @@ local function customCLEU(self, ...)
         elseif (spellID == lunarSpellID) then
             lunarCache = true;
             updateSAOs(self);
+            updateGABs(self);
         elseif (spellID == solarSpellID) then
             solarCache = true;
             updateSAOs(self);
+            updateGABs(self);
         end
         return;
     elseif (event == "SPELL_AURA_REMOVED") then
@@ -127,9 +157,11 @@ local function customCLEU(self, ...)
         elseif (spellID == lunarSpellID) then
             lunarCache = false;
             updateSAOs(self);
+            updateGABs(self);
         elseif (spellID == solarSpellID) then
             solarCache = false;
             updateSAOs(self);
+            updateGABs(self);
         end
         return;
     end
@@ -142,6 +174,19 @@ local function registerClass(self)
 
     -- Track Omen of Clarity with a custom CLEU function, to be able to switch between feral and non-feral texture
     -- self:RegisterAura("omen_of_clarity", 0, 16870, "natures_grace", "Left + Right (Flipped)", 1, 255, 255, 255, true);
+
+    -- Register glow IDs for glowing buttons, namely Starfire and Wrath
+    local starfire = GetSpellInfo(2912);
+    local wrath = GetSpellInfo(5176);
+    for _, glowID in ipairs({ starfire, wrath }) do
+        if (not SAO.RegisteredGlowSpellNames[glowID]) then
+            SAO.RegisteredGlowSpellNames[glowID] = true;
+            local glowSpellIDs = self:GetSpellIDsByName(glowID);
+            for _, glowSpellID in ipairs(glowSpellIDs) do
+                self.RegisteredGlowSpellIDs[glowSpellID] = true;
+            end
+        end
+    end
 end
 
 SAO.Class["DRUID"] = {

--- a/classes/druid.lua
+++ b/classes/druid.lua
@@ -178,15 +178,7 @@ local function registerClass(self)
     -- Register glow IDs for glowing buttons, namely Starfire and Wrath
     local starfire = GetSpellInfo(2912);
     local wrath = GetSpellInfo(5176);
-    for _, glowID in ipairs({ starfire, wrath }) do
-        if (not SAO.RegisteredGlowSpellNames[glowID]) then
-            SAO.RegisteredGlowSpellNames[glowID] = true;
-            local glowSpellIDs = self:GetSpellIDsByName(glowID);
-            for _, glowSpellID in ipairs(glowSpellIDs) do
-                self.RegisteredGlowSpellIDs[glowSpellID] = true;
-            end
-        end
-    end
+    self:RegisterGlowIDs({ starfire, wrath });
 end
 
 SAO.Class["DRUID"] = {

--- a/classes/hunter.lua
+++ b/classes/hunter.lua
@@ -1,8 +1,14 @@
 local AddonName, SAO = ...
 
 local function registerClass(self)
+    local aimedShot = 19434;
+    local arcaneShot = 3044;
+    local chimeraShot = 53209;
+
+    local issGlowNames = { GetSpellInfo(aimedShot), GetSpellInfo(arcaneShot), GetSpellInfo(chimeraShot) };
+
     -- Improved Steady Shot, formerly Master Marksman
-    self:RegisterAura("improved_steady_shot", 0, 53220, "master_marksman", "Top", 1, 255, 255, 255, true);
+    self:RegisterAura("improved_steady_shot", 0, 53220, "master_marksman", "Top", 1, 255, 255, 255, true, issGlowNames);
 
     -- Lock and Load, option 1: display something on top if there is at least one charge
     -- Advantage: easier to see

--- a/classes/hunter.lua
+++ b/classes/hunter.lua
@@ -5,6 +5,7 @@ local function registerClass(self)
     local arcaneShot = 3044;
     local chimeraShot = 53209;
     local explosiveShot = 53301;
+    local counterattack = 19306;
 
     local issGlowNames = { GetSpellInfo(aimedShot), GetSpellInfo(arcaneShot), GetSpellInfo(chimeraShot) };
     local lalGlowNames = { GetSpellInfo(arcaneShot), GetSpellInfo(explosiveShot) };
@@ -24,6 +25,10 @@ local function registerClass(self)
     -- self:RegisterAura("lock_and_load", 1, 56453, "lock_and_load", "TopLeft", 1, 255, 255, 255, true, lalGlowNames);
     -- self:RegisterAura("lock_and_load_2left", 2, 56453, "lock_and_load", "TopLeft", 1, 255, 255, 255, true, lalGlowNames);
     -- self:RegisterAura("lock_and_load_2right", 2, 56453, "lock_and_load", "TopRight", 1, 255, 255, 255, true, lalGlowNames);
+
+    -- Counterattack, registered as both aura and counter, but only used as counter
+    self:RegisterAura("counterattack", 0, counterattack, nil, "", 0, 0, 0, 0, false, { (GetSpellInfo(counterattack)) });
+    self:RegisterCounter("counterattack"); -- Must match name from above call
 end
 
 SAO.Class["HUNTER"] = {

--- a/classes/hunter.lua
+++ b/classes/hunter.lua
@@ -7,8 +7,8 @@ local function registerClass(self)
     local explosiveShot = 53301;
     local counterattack = 19306;
 
-    local issGlowNames = { GetSpellInfo(aimedShot), GetSpellInfo(arcaneShot), GetSpellInfo(chimeraShot) };
-    local lalGlowNames = { GetSpellInfo(arcaneShot), GetSpellInfo(explosiveShot) };
+    local issGlowNames = { (GetSpellInfo(aimedShot)), (GetSpellInfo(arcaneShot)), (GetSpellInfo(chimeraShot)) };
+    local lalGlowNames = { (GetSpellInfo(arcaneShot)), (GetSpellInfo(explosiveShot)) };
 
     -- Improved Steady Shot, formerly Master Marksman
     self:RegisterAura("improved_steady_shot", 0, 53220, "master_marksman", "Top", 1, 255, 255, 255, true, issGlowNames);

--- a/classes/hunter.lua
+++ b/classes/hunter.lua
@@ -4,8 +4,10 @@ local function registerClass(self)
     local aimedShot = 19434;
     local arcaneShot = 3044;
     local chimeraShot = 53209;
+    local explosiveShot = 53301;
 
     local issGlowNames = { GetSpellInfo(aimedShot), GetSpellInfo(arcaneShot), GetSpellInfo(chimeraShot) };
+    local lalGlowNames = { GetSpellInfo(arcaneShot), GetSpellInfo(explosiveShot) };
 
     -- Improved Steady Shot, formerly Master Marksman
     self:RegisterAura("improved_steady_shot", 0, 53220, "master_marksman", "Top", 1, 255, 255, 255, true, issGlowNames);
@@ -13,15 +15,15 @@ local function registerClass(self)
     -- Lock and Load, option 1: display something on top if there is at least one charge
     -- Advantage: easier to see
     -- Disadvantages: doesn't show the number of charges, may conflict with Improved Steady Shot
-    self:RegisterAura("lock_and_load_1", 1, 56453, "lock_and_load", "Top", 1, 255, 255, 255, true);
-    self:RegisterAura("lock_and_load_2", 2, 56453, "lock_and_load", "Top", 1, 255, 255, 255, true);
+    self:RegisterAura("lock_and_load_1", 1, 56453, "lock_and_load", "Top", 1, 255, 255, 255, true, lalGlowNames);
+    self:RegisterAura("lock_and_load_2", 2, 56453, "lock_and_load", "Top", 1, 255, 255, 255, true, lalGlowNames);
 
     -- Lock and Load, option 2: display the first charge on top-left and second charge on top-right
     -- Advantages: displays two charges, doesn't conflict with Improved Steady Shot
     -- Disadvantage: weird place to put them (smaller, away from the center)
-    -- self:RegisterAura("lock_and_load", 1, 56453, "lock_and_load", "TopLeft", 1, 255, 255, 255, true);
-    -- self:RegisterAura("lock_and_load_2left", 2, 56453, "lock_and_load", "TopLeft", 1, 255, 255, 255, true);
-    -- self:RegisterAura("lock_and_load_2right", 2, 56453, "lock_and_load", "TopRight", 1, 255, 255, 255, true);
+    -- self:RegisterAura("lock_and_load", 1, 56453, "lock_and_load", "TopLeft", 1, 255, 255, 255, true, lalGlowNames);
+    -- self:RegisterAura("lock_and_load_2left", 2, 56453, "lock_and_load", "TopLeft", 1, 255, 255, 255, true, lalGlowNames);
+    -- self:RegisterAura("lock_and_load_2right", 2, 56453, "lock_and_load", "TopRight", 1, 255, 255, 255, true, lalGlowNames);
 end
 
 SAO.Class["HUNTER"] = {

--- a/classes/mage.lua
+++ b/classes/mage.lua
@@ -157,7 +157,7 @@ end
 
 local function registerClass(self)
     -- Fire Procs
-    self:RegisterAura("impact", 0, 64343, "impact", "Top", 1, 255, 255, 255);
+    self:RegisterAura("impact", 0, 64343, "impact", "Top", 1, 255, 255, 255, true, { GetSpellInfo(2136) });
     self:RegisterAura("hot_streak_full", 0, hotStreakSpellID, "hot_streak", "Left + Right (Flipped)", 1, 255, 255, 255, true, { GetSpellInfo(11366) });
     --self:RegisterAura("hot_streak_half", 0, heatingUpSpellID, "hot_streak", "Left + Right (Flipped)", 0.5, 255, 255, 255, false);
     -- Heating Up (spellID == 48107) doesn't exist in Wrath Classic, so we can't use the above aura

--- a/classes/mage.lua
+++ b/classes/mage.lua
@@ -157,8 +157,8 @@ end
 
 local function registerClass(self)
     -- Fire Procs
-    self:RegisterAura("impact", 0, 64343, "impact", "Top", 1, 255, 255, 255, true, { GetSpellInfo(2136) });
-    self:RegisterAura("hot_streak_full", 0, hotStreakSpellID, "hot_streak", "Left + Right (Flipped)", 1, 255, 255, 255, true, { GetSpellInfo(11366) });
+    self:RegisterAura("impact", 0, 64343, "impact", "Top", 1, 255, 255, 255, true, { (GetSpellInfo(2136)) });
+    self:RegisterAura("hot_streak_full", 0, hotStreakSpellID, "hot_streak", "Left + Right (Flipped)", 1, 255, 255, 255, true, { (GetSpellInfo(11366)) });
     --self:RegisterAura("hot_streak_half", 0, heatingUpSpellID, "hot_streak", "Left + Right (Flipped)", 0.5, 255, 255, 255, false);
     -- Heating Up (spellID == 48107) doesn't exist in Wrath Classic, so we can't use the above aura
     -- Instead, we track Fire Blast, Fireball, Living Bomb and Scorch non-periodic critical strikes
@@ -167,10 +167,10 @@ local function registerClass(self)
     -- Frost Procs
     self:RegisterAura("fingers_of_frost_1", 1, 74396, "frozen_fingers", "Left", 1, 255, 255, 255, true);
     self:RegisterAura("fingers_of_frost_2", 2, 74396, "frozen_fingers", "Left + Right (Flipped)", 1, 255, 255, 255, true);
-    self:RegisterAura("brain_freeze", 0, 57761, "brain_freeze", "Top", 1, 255, 255, 255, true, { GetSpellInfo(133), GetSpellInfo(44614) });
+    self:RegisterAura("brain_freeze", 0, 57761, "brain_freeze", "Top", 1, 255, 255, 255, true, { (GetSpellInfo(133)), (GetSpellInfo(44614)) });
 
     -- Arcane Procs
-    self:RegisterAura("missile_barrage", 0, 44401, "arcane_missiles", "Left + Right (Flipped)", 1, 255, 255, 255, true, { GetSpellInfo(5143) });
+    self:RegisterAura("missile_barrage", 0, 44401, "arcane_missiles", "Left + Right (Flipped)", 1, 255, 255, 255, true, { (GetSpellInfo(5143)) });
 end
 
 SAO.Class["MAGE"] = {

--- a/classes/mage.lua
+++ b/classes/mage.lua
@@ -170,7 +170,7 @@ local function registerClass(self)
     self:RegisterAura("brain_freeze", 0, 57761, "brain_freeze", "Top", 1, 255, 255, 255, true, { GetSpellInfo(133), GetSpellInfo(44614) });
 
     -- Arcane Procs
-    self:RegisterAura("missile_barrage", 0, 44401, "arcane_missiles", "Left + Right (Flipped)", 1, 255, 255, 255, true);
+    self:RegisterAura("missile_barrage", 0, 44401, "arcane_missiles", "Left + Right (Flipped)", 1, 255, 255, 255, true, { GetSpellInfo(5143) });
 end
 
 SAO.Class["MAGE"] = {

--- a/classes/mage.lua
+++ b/classes/mage.lua
@@ -158,7 +158,7 @@ end
 local function registerClass(self)
     -- Fire Procs
     self:RegisterAura("impact", 0, 64343, "impact", "Top", 1, 255, 255, 255);
-    self:RegisterAura("hot_streak_full", 0, hotStreakSpellID, "hot_streak", "Left + Right (Flipped)", 1, 255, 255, 255, true);
+    self:RegisterAura("hot_streak_full", 0, hotStreakSpellID, "hot_streak", "Left + Right (Flipped)", 1, 255, 255, 255, true, { GetSpellInfo(11366) });
     --self:RegisterAura("hot_streak_half", 0, heatingUpSpellID, "hot_streak", "Left + Right (Flipped)", 0.5, 255, 255, 255, false);
     -- Heating Up (spellID == 48107) doesn't exist in Wrath Classic, so we can't use the above aura
     -- Instead, we track Fire Blast, Fireball, Living Bomb and Scorch non-periodic critical strikes

--- a/classes/mage.lua
+++ b/classes/mage.lua
@@ -167,7 +167,7 @@ local function registerClass(self)
     -- Frost Procs
     self:RegisterAura("fingers_of_frost_1", 1, 74396, "frozen_fingers", "Left", 1, 255, 255, 255, true);
     self:RegisterAura("fingers_of_frost_2", 2, 74396, "frozen_fingers", "Left + Right (Flipped)", 1, 255, 255, 255, true);
-    self:RegisterAura("brain_freeze", 0, 57761, "brain_freeze", "Top", 1, 255, 255, 255, true);
+    self:RegisterAura("brain_freeze", 0, 57761, "brain_freeze", "Top", 1, 255, 255, 255, true, { GetSpellInfo(133), GetSpellInfo(44614) });
 
     -- Arcane Procs
     self:RegisterAura("missile_barrage", 0, 44401, "arcane_missiles", "Left + Right (Flipped)", 1, 255, 255, 255, true);

--- a/classes/paladin.lua
+++ b/classes/paladin.lua
@@ -5,10 +5,10 @@ local function registerClass(self)
     self:RegisterAura("art_of_war", 0, 59578, "art_of_war", "Left + Right (Flipped)", 1, 255, 255, 255, true);
 
     -- Infusion of Light, 1/2 talent points
-    self:RegisterAura("infusion_of_light_low", 0, 53672, "daybreak", "Left + Right (Flipped)", 1, 255, 255, 255, true);
+    self:RegisterAura("infusion_of_light_low", 0, 53672, "daybreak", "Left + Right (Flipped)", 1, 255, 255, 255, true, { GetSpellInfo(19750), GetSpellInfo(635) });
 
     -- Infusion of Light, 2/2 talent points
-    self:RegisterAura("infusion_of_light_high", 0, 54149, "daybreak", "Left + Right (Flipped)", 1, 255, 255, 255, true);
+    self:RegisterAura("infusion_of_light_high", 0, 54149, "daybreak", "Left + Right (Flipped)", 1, 255, 255, 255, true, { GetSpellInfo(19750), GetSpellInfo(635) });
 end
 
 SAO.Class["PALADIN"] = {

--- a/classes/paladin.lua
+++ b/classes/paladin.lua
@@ -2,7 +2,7 @@ local AddonName, SAO = ...
 
 local function registerClass(self)
     -- Art of War
-    self:RegisterAura("art_of_war", 0, 59578, "art_of_war", "Left + Right (Flipped)", 1, 255, 255, 255, true);
+    self:RegisterAura("art_of_war", 0, 59578, "art_of_war", "Left + Right (Flipped)", 1, 255, 255, 255, true, { GetSpellInfo(19750), GetSpellInfo(879) });
 
     -- Infusion of Light, 1/2 talent points
     self:RegisterAura("infusion_of_light_low", 0, 53672, "daybreak", "Left + Right (Flipped)", 1, 255, 255, 255, true, { GetSpellInfo(19750), GetSpellInfo(635) });

--- a/classes/paladin.lua
+++ b/classes/paladin.lua
@@ -1,14 +1,18 @@
 local AddonName, SAO = ...
 
 local function registerClass(self)
+    local flashOfLight = GetSpellInfo(19750);
+    local exorcism = GetSpellInfo(879);
+    local holyLight = GetSpellInfo(635);
+
     -- Art of War
-    self:RegisterAura("art_of_war", 0, 59578, "art_of_war", "Left + Right (Flipped)", 1, 255, 255, 255, true, { GetSpellInfo(19750), GetSpellInfo(879) });
+    self:RegisterAura("art_of_war", 0, 59578, "art_of_war", "Left + Right (Flipped)", 1, 255, 255, 255, true, { flashOfLight, exorcism });
 
     -- Infusion of Light, 1/2 talent points
-    self:RegisterAura("infusion_of_light_low", 0, 53672, "daybreak", "Left + Right (Flipped)", 1, 255, 255, 255, true, { GetSpellInfo(19750), GetSpellInfo(635) });
+    self:RegisterAura("infusion_of_light_low", 0, 53672, "daybreak", "Left + Right (Flipped)", 1, 255, 255, 255, true, { flashOfLight, holyLight });
 
     -- Infusion of Light, 2/2 talent points
-    self:RegisterAura("infusion_of_light_high", 0, 54149, "daybreak", "Left + Right (Flipped)", 1, 255, 255, 255, true, { GetSpellInfo(19750), GetSpellInfo(635) });
+    self:RegisterAura("infusion_of_light_high", 0, 54149, "daybreak", "Left + Right (Flipped)", 1, 255, 255, 255, true, { flashOfLight, holyLight });
 end
 
 SAO.Class["PALADIN"] = {

--- a/classes/priest.lua
+++ b/classes/priest.lua
@@ -1,9 +1,11 @@
 local AddonName, SAO = ...
 
 local function registerClass(self)
-    self:RegisterAura("surge_of_light", 0, 33151, "surge_of_light", "Left + Right (Flipped)", 1, 255, 255, 255, true, { GetSpellInfo(585), GetSpellInfo(2061) });
+    local smite = GetSpellInfo(585);
+    local flashHeal = GetSpellInfo(2061);
+    self:RegisterAura("surge_of_light", 0, 33151, "surge_of_light", "Left + Right (Flipped)", 1, 255, 255, 255, true, { smite, flashHeal });
 
-    local ghAndPoh = { GetSpellInfo(2060), GetSpellInfo(596) }
+    local ghAndPoh = { (GetSpellInfo(2060)), (GetSpellInfo(596)) }
 
     -- Serendipity with 1 talent point out of 3
 --    self:RegisterAura("serendipity_low_1", 1, 63731, "serendipity", "Top", 0.25, 255, 255, 255, true, ghAndPoh);

--- a/classes/priest.lua
+++ b/classes/priest.lua
@@ -1,7 +1,7 @@
 local AddonName, SAO = ...
 
 local function registerClass(self)
-    self:RegisterAura("surge_of_light", 0, 33151, "surge_of_light", "Left + Right (Flipped)", 1, 255, 255, 255, true);
+    self:RegisterAura("surge_of_light", 0, 33151, "surge_of_light", "Left + Right (Flipped)", 1, 255, 255, 255, true, { GetSpellInfo(585), GetSpellInfo(2061) });
 
     -- Serendipity with 1 talent point out of 3
 --    self:RegisterAura("serendipity_low_1", 1, 63731, "serendipity", "Top", 0.25, 255, 255, 255, true);

--- a/classes/priest.lua
+++ b/classes/priest.lua
@@ -3,20 +3,22 @@ local AddonName, SAO = ...
 local function registerClass(self)
     self:RegisterAura("surge_of_light", 0, 33151, "surge_of_light", "Left + Right (Flipped)", 1, 255, 255, 255, true, { GetSpellInfo(585), GetSpellInfo(2061) });
 
+    local ghAndPoh = { GetSpellInfo(2060), GetSpellInfo(596) }
+
     -- Serendipity with 1 talent point out of 3
---    self:RegisterAura("serendipity_low_1", 1, 63731, "serendipity", "Top", 0.25, 255, 255, 255, true);
---    self:RegisterAura("serendipity_low_2", 2, 63731, "serendipity", "Top", 0.5, 255, 255, 255, true);
-    self:RegisterAura("serendipity_low_3", 3, 63731, "serendipity", "Top", 1, 255, 255, 255, true);
+--    self:RegisterAura("serendipity_low_1", 1, 63731, "serendipity", "Top", 0.25, 255, 255, 255, true, ghAndPoh);
+--    self:RegisterAura("serendipity_low_2", 2, 63731, "serendipity", "Top", 0.5, 255, 255, 255, true, ghAndPoh);
+    self:RegisterAura("serendipity_low_3", 3, 63731, "serendipity", "Top", 1, 255, 255, 255, true, ghAndPoh);
 
     -- Serendipity with 2 talent points out of 3
---    self:RegisterAura("serendipity_medium_1", 1, 63735, "serendipity", "Top", 0.25, 255, 255, 255, true);
---    self:RegisterAura("serendipity_medium_2", 2, 63735, "serendipity", "Top", 0.5, 255, 255, 255, true);
-    self:RegisterAura("serendipity_medium_3", 3, 63735, "serendipity", "Top", 1, 255, 255, 255, true);
+--    self:RegisterAura("serendipity_medium_1", 1, 63735, "serendipity", "Top", 0.25, 255, 255, 255, true, ghAndPoh);
+--    self:RegisterAura("serendipity_medium_2", 2, 63735, "serendipity", "Top", 0.5, 255, 255, 255, true, ghAndPoh);
+    self:RegisterAura("serendipity_medium_3", 3, 63735, "serendipity", "Top", 1, 255, 255, 255, true, ghAndPoh);
 
     -- Serendipity with 3 talent points out of 3
---    self:RegisterAura("serendipity_high_1", 1, 63734, "serendipity", "Top", 0.25, 255, 255, 255, true);
---    self:RegisterAura("serendipity_high_2", 2, 63734, "serendipity", "Top", 0.5, 255, 255, 255, true);
-    self:RegisterAura("serendipity_high_3", 3, 63734, "serendipity", "Top", 1, 255, 255, 255, true);
+--    self:RegisterAura("serendipity_high_1", 1, 63734, "serendipity", "Top", 0.25, 255, 255, 255, true, ghAndPoh);
+--    self:RegisterAura("serendipity_high_2", 2, 63734, "serendipity", "Top", 0.5, 255, 255, 255, true, ghAndPoh);
+    self:RegisterAura("serendipity_high_3", 3, 63734, "serendipity", "Top", 1, 255, 255, 255, true, ghAndPoh);
 end
 
 SAO.Class["PRIEST"] = {

--- a/classes/rogue.lua
+++ b/classes/rogue.lua
@@ -1,57 +1,13 @@
 local AddonName, SAO = ...
 
-local riposteSpellID = 14251;
-
-local isRiposteActivated = false;
-
-local retryTimer = nil;
-
-local function customSpellUpdate(self, ...)
-    local start, duration, enabled, modRate = GetSpellCooldown(riposteSpellID);
-    if (type(start) ~= "number") then
-        -- Spell not available
-        return
-    end
-
-    local isRiposteUsable = IsUsableSpell(riposteSpellID);
-    local riposteMustBeActivated = isRiposteUsable and start == 0;
-
-    if (not isRiposteActivated and riposteMustBeActivated) then
-        -- Riposte triggered but not shown yet: just do it!
-        isRiposteActivated = true;
-        self:ActivateOverlay(0, riposteSpellID, self.TexName["bandits_guile"], "Top (CW)", 1, 255, 255, 255, true);
-        self:AddGlow(riposteSpellID, {riposteSpellID}); -- Same spell ID, because there is no 'aura'
-    elseif (isRiposteActivated and not riposteMustBeActivated) then
-        -- Riposte not triggered but still shown: hide it
-        isRiposteActivated = false;
-        self:DeactivateOverlay(riposteSpellID);
-        self:RemoveGlow(riposteSpellID);
-    end
-    
-    if (isRiposteUsable and start > 0) then
-        -- Riposte could be usable, but CD prevents us to: try again in a few seconds
-        local endTime = start+duration;
-
-        if (not retryTimer or retryTimer.endTime ~= endTime) then
-            if (retryTimer) then
-                retryTimer:Cancel();
-            end
-
-            local remainingTime = endTime-GetTime();
-            local delta = 0.05; -- Add a small delay to account for lags and whatnot
-            local retryFunc = function(...) customSpellUpdate(self, ...); end;
-            retryTimer = C_Timer.NewTimer(remainingTime+delta, retryFunc);
-            retryTimer.endTime = endTime;
-        end
-    end
-end
-
 local function registerClass(self)
-    -- Register Riposte's spell ID
-    SAO.RegisteredGlowSpellIDs[riposteSpellID] = true;
+    -- Register Riposte as both an aura and a counter
+    -- Rogue does not really have a 'Riposte' aura, but it will be used by RegisterCounter
+    local riposteSpellID = 14251;
+    self:RegisterAura("riposte", 0, riposteSpellID, "bandits_guile", "Top (CW)", 1, 255, 255, 255, true, { riposteSpellID });
+    self:RegisterCounter("riposte"); -- Must match name from above call
 end
 
 SAO.Class["ROGUE"] = {
     ["Register"] = registerClass,
-    ["SPELL_UPDATE_USABLE"] = customSpellUpdate,
 }

--- a/classes/rogue.lua
+++ b/classes/rogue.lua
@@ -48,7 +48,7 @@ end
 
 local function registerClass(self)
     -- Register Riposte's spell ID
-    SAO.RegisteredGlowIDs[riposteSpellID] = true;
+    SAO.RegisteredGlowSpellIDs[riposteSpellID] = true;
 end
 
 SAO.Class["ROGUE"] = {

--- a/classes/warlock.lua
+++ b/classes/warlock.lua
@@ -1,29 +1,32 @@
 local AddonName, SAO = ...
 
-local function registerMolenCore(self, baseName, spellID)
-    local incinerateAndSoulFire = { GetSpellInfo(29722), GetSpellInfo(6353) };
-
-    self:RegisterAura(baseName.."_1", 1, spellID, "molten_core", "Left", 1, 255, 255, 255, true, incinerateAndSoulFire);
-    self:RegisterAura(baseName.."_2", 2, spellID, "molten_core", "Left + Right (Flipped)", 1, 255, 255, 255, true, incinerateAndSoulFire);
-    self:RegisterAura(baseName.."_3", 3, spellID, "molten_core", "Left + Right (Flipped)", 1, 255, 255, 255, true, incinerateAndSoulFire);
-    self:RegisterAura(baseName.."_3_top", 3, spellID, "lock_and_load", "Top", 1, 255, 255, 255, true --[[, incinerateAndSoulFire]]);
---    self:RegisterAura(baseName.."_3_top", 3, spellID, "impact", "Top", 1, 255, 255, 255, true --[[, incinerateAndSoulFire]]);
+local function registerMolenCore(self, baseName, spellID, glowIDs)
+    self:RegisterAura(baseName.."_1", 1, spellID, "molten_core", "Left", 1, 255, 255, 255, true, glowIDs);
+    self:RegisterAura(baseName.."_2", 2, spellID, "molten_core", "Left + Right (Flipped)", 1, 255, 255, 255, true, glowIDs);
+    self:RegisterAura(baseName.."_3", 3, spellID, "molten_core", "Left + Right (Flipped)", 1, 255, 255, 255, true, glowIDs);
+    self:RegisterAura(baseName.."_3_top", 3, spellID, "lock_and_load", "Top", 1, 255, 255, 255, true --[[, glowIDs]]);
+--    self:RegisterAura(baseName.."_3_top", 3, spellID, "impact", "Top", 1, 255, 255, 255, true --[[, glowIDs]]);
 end
 
 local function registerClass(self)
+    local shadowBolt = GetSpellInfo(686);
+    local incinerate = GetSpellInfo(29722);
+    local soulFire = GetSpellInfo(6353);
+    local incinerateAndSoulFire = { incinerate, soulFire };
+
     -- Backlash
-    self:RegisterAura("backlash", 0, 34936, "backlash", "Top", 1, 255, 255, 255, true, { GetSpellInfo(686), GetSpellInfo(29722) });
+    self:RegisterAura("backlash", 0, 34936, "backlash", "Top", 1, 255, 255, 255, true, { shadowBolt, incinerate });
 
     -- Empowered Imp
     self:RegisterAura("empowered_imp", 0, 47283, "imp_empowerment", "Left + Right (Flipped)", 1, 255, 255, 255, true);
 
     -- Molten Core
-    registerMolenCore(self, "molten_core_low", 47383); -- 1/3 talent point
-    registerMolenCore(self, "molten_core_medium", 71162); -- 2/3 talent points
-    registerMolenCore(self, "molten_core_high", 71165); -- 3/3 talent points
+    registerMolenCore(self, "molten_core_low", 47383, incinerateAndSoulFire); -- 1/3 talent point
+    registerMolenCore(self, "molten_core_medium", 71162, incinerateAndSoulFire); -- 2/3 talent points
+    registerMolenCore(self, "molten_core_high", 71165, incinerateAndSoulFire); -- 3/3 talent points
 
     -- Nightfall / Shadow Trance
-    self:RegisterAura("nightfall", 0, 17941, "nightfall", "Left + Right (Flipped)", 1, 255, 255, 255, true, { GetSpellInfo(686) });
+    self:RegisterAura("nightfall", 0, 17941, "nightfall", "Left + Right (Flipped)", 1, 255, 255, 255, true, { shadowBolt });
 end
 
 SAO.Class["WARLOCK"] = {

--- a/classes/warlock.lua
+++ b/classes/warlock.lua
@@ -1,11 +1,13 @@
 local AddonName, SAO = ...
 
 local function registerMolenCore(self, baseName, spellID)
-    self:RegisterAura(baseName.."_1", 1, spellID, "molten_core", "Left", 1, 255, 255, 255, true);
-    self:RegisterAura(baseName.."_2", 2, spellID, "molten_core", "Left + Right (Flipped)", 1, 255, 255, 255, true);
-    self:RegisterAura(baseName.."_3", 3, spellID, "molten_core", "Left + Right (Flipped)", 1, 255, 255, 255, true);
-    self:RegisterAura(baseName.."_3_top", 3, spellID, "lock_and_load", "Top", 1, 255, 255, 255, true);
---    self:RegisterAura(baseName.."_3_top", 3, spellID, "impact", "Top", 1, 255, 255, 255, true);
+    local incinerateAndSoulFire = { GetSpellInfo(29722), GetSpellInfo(6353) };
+
+    self:RegisterAura(baseName.."_1", 1, spellID, "molten_core", "Left", 1, 255, 255, 255, true, incinerateAndSoulFire);
+    self:RegisterAura(baseName.."_2", 2, spellID, "molten_core", "Left + Right (Flipped)", 1, 255, 255, 255, true, incinerateAndSoulFire);
+    self:RegisterAura(baseName.."_3", 3, spellID, "molten_core", "Left + Right (Flipped)", 1, 255, 255, 255, true, incinerateAndSoulFire);
+    self:RegisterAura(baseName.."_3_top", 3, spellID, "lock_and_load", "Top", 1, 255, 255, 255, true --[[, incinerateAndSoulFire]]);
+--    self:RegisterAura(baseName.."_3_top", 3, spellID, "impact", "Top", 1, 255, 255, 255, true --[[, incinerateAndSoulFire]]);
 end
 
 local function registerClass(self)

--- a/classes/warlock.lua
+++ b/classes/warlock.lua
@@ -21,7 +21,7 @@ local function registerClass(self)
     registerMolenCore(self, "molten_core_high", 71165); -- 3/3 talent points
 
     -- Nightfall / Shadow Trance
-    self:RegisterAura("nightfall", 0, 17941, "nightfall", "Left + Right (Flipped)", 1, 255, 255, 255, true);
+    self:RegisterAura("nightfall", 0, 17941, "nightfall", "Left + Right (Flipped)", 1, 255, 255, 255, true, { GetSpellInfo(686) });
 end
 
 SAO.Class["WARLOCK"] = {

--- a/classes/warlock.lua
+++ b/classes/warlock.lua
@@ -10,7 +10,7 @@ end
 
 local function registerClass(self)
     -- Backlash
-    self:RegisterAura("backlash", 0, 34936, "backlash", "Top", 1, 255, 255, 255, true);
+    self:RegisterAura("backlash", 0, 34936, "backlash", "Top", 1, 255, 255, 255, true, { GetSpellInfo(686), GetSpellInfo(29722) });
 
     -- Empowered Imp
     self:RegisterAura("empowered_imp", 0, 47283, "imp_empowerment", "Left + Right (Flipped)", 1, 255, 255, 255, true);

--- a/classes/warrior.lua
+++ b/classes/warrior.lua
@@ -6,11 +6,11 @@ local function registerClass(self)
     self:RegisterAura("sword_and_board", 0, 50227, "sword_and_board", "Left + Right (Flipped)", 1, 255, 255, 255, true, { GetSpellInfo(23922) });
 
     local overpower = 7384;
-    self:RegisterAura("overpower", 0, overpower, nil, "", 0, 0, 0, 0, false, { GetSpellInfo(overpower) });
+    self:RegisterAura("overpower", 0, overpower, nil, "", 0, 0, 0, 0, false, { (GetSpellInfo(overpower)) });
     self:RegisterCounter("overpower"); -- Must match name from above call
 
     local revenge = 6572;
-    self:RegisterAura("revenge", 0, revenge, nil, "", 0, 0, 0, 0, false, { GetSpellInfo(revenge) });
+    self:RegisterAura("revenge", 0, revenge, nil, "", 0, 0, 0, 0, false, { (GetSpellInfo(revenge)) });
     self:RegisterCounter("revenge"); -- Must match name from above call
 end
 

--- a/classes/warrior.lua
+++ b/classes/warrior.lua
@@ -8,6 +8,10 @@ local function registerClass(self)
     local overpower = 7384;
     self:RegisterAura("overpower", 0, overpower, nil, "", 0, 0, 0, 0, false, { GetSpellInfo(overpower) });
     self:RegisterCounter("overpower"); -- Must match name from above call
+
+    local revenge = 6572;
+    self:RegisterAura("revenge", 0, revenge, nil, "", 0, 0, 0, 0, false, { GetSpellInfo(revenge) });
+    self:RegisterCounter("revenge"); -- Must match name from above call
 end
 
 SAO.Class["WARRIOR"] = {

--- a/classes/warrior.lua
+++ b/classes/warrior.lua
@@ -1,7 +1,7 @@
 local AddonName, SAO = ...
 
 local function registerClass(self)
-    self:RegisterAura("bloodsurge", 0, 46916, "blood_surge", "Top", 1, 255, 255, 255, true);
+    self:RegisterAura("bloodsurge", 0, 46916, "blood_surge", "Top", 1, 255, 255, 255, true, { GetSpellInfo(1464) });
     self:RegisterAura("sudden_death", 0, 52437, "sudden_death", "Left + Right (Flipped)", 1, 255, 255, 255, true);
     self:RegisterAura("sword_and_board", 0, 50227, "sword_and_board", "Left + Right (Flipped)", 1, 255, 255, 255, true, { GetSpellInfo(23922) });
 end

--- a/classes/warrior.lua
+++ b/classes/warrior.lua
@@ -3,7 +3,7 @@ local AddonName, SAO = ...
 local function registerClass(self)
     self:RegisterAura("bloodsurge", 0, 46916, "blood_surge", "Top", 1, 255, 255, 255, true);
     self:RegisterAura("sudden_death", 0, 52437, "sudden_death", "Left + Right (Flipped)", 1, 255, 255, 255, true);
-    self:RegisterAura("sword_and_board", 0, 50227, "sword_and_board", "Left + Right (Flipped)", 1, 255, 255, 255, true);
+    self:RegisterAura("sword_and_board", 0, 50227, "sword_and_board", "Left + Right (Flipped)", 1, 255, 255, 255, true, { GetSpellInfo(23922) });
 end
 
 SAO.Class["WARRIOR"] = {

--- a/classes/warrior.lua
+++ b/classes/warrior.lua
@@ -2,7 +2,7 @@ local AddonName, SAO = ...
 
 local function registerClass(self)
     self:RegisterAura("bloodsurge", 0, 46916, "blood_surge", "Top", 1, 255, 255, 255, true, { GetSpellInfo(1464) });
-    self:RegisterAura("sudden_death", 0, 52437, "sudden_death", "Left + Right (Flipped)", 1, 255, 255, 255, true);
+    self:RegisterAura("sudden_death", 0, 52437, "sudden_death", "Left + Right (Flipped)", 1, 255, 255, 255, true, { GetSpellInfo(5308) });
     self:RegisterAura("sword_and_board", 0, 50227, "sword_and_board", "Left + Right (Flipped)", 1, 255, 255, 255, true, { GetSpellInfo(23922) });
 end
 

--- a/classes/warrior.lua
+++ b/classes/warrior.lua
@@ -4,6 +4,10 @@ local function registerClass(self)
     self:RegisterAura("bloodsurge", 0, 46916, "blood_surge", "Top", 1, 255, 255, 255, true, { GetSpellInfo(1464) });
     self:RegisterAura("sudden_death", 0, 52437, "sudden_death", "Left + Right (Flipped)", 1, 255, 255, 255, true, { GetSpellInfo(5308) });
     self:RegisterAura("sword_and_board", 0, 50227, "sword_and_board", "Left + Right (Flipped)", 1, 255, 255, 255, true, { GetSpellInfo(23922) });
+
+    local overpower = 7384;
+    self:RegisterAura("overpower", 0, overpower, nil, "", 0, 0, 0, 0, false, { GetSpellInfo(overpower) });
+    self:RegisterCounter("overpower"); -- Must match name from above call
 end
 
 SAO.Class["WARRIOR"] = {

--- a/counter.lua
+++ b/counter.lua
@@ -18,8 +18,21 @@ SAO.CounterRetryTimers = {};
 -- @param auraID name of the aura registered to SAO.RegisterAura
 function SAO.RegisterCounter(self, auraID)
     local aura = self.RegisteredAurasByName[auraID];
-    local spellID = select(3,unpack(aura));
-    self.ActivableCounters[spellID] = auraID;
+    if (not aura) then
+        return;
+    end
+
+    local glowIDs = select(11,unpack(aura));
+    for _, glowID in ipairs(glowIDs or {}) do
+        if (type(glowID) == "number") then
+            self.ActivableCounters[glowID] = auraID;
+        elseif (type(glowID) == "string") then
+            local glowSpellIDs = self:GetSpellIDsByName(glowID);
+            for _, glowSpellID in ipairs(glowSpellIDs) do
+                self.ActivableCounters[glowSpellID] = auraID;
+            end
+        end
+    end
 end
 
 -- Check if an action counter became either activated or deactivated

--- a/counter.lua
+++ b/counter.lua
@@ -1,0 +1,76 @@
+local AddonName, SAO = ...
+
+-- List of spell IDs of actions that can trigger as 'counter'
+-- key = spellID, value = auraID
+SAO.ActivableCounters = {};
+
+-- List of spell IDs currently
+-- key = spellID, value = true
+SAO.ActivatedCounters = {};
+
+-- List of timer objects for checking cooldown of activated counters
+-- key = spellID, value = timer object
+SAO.CounterRetryTimers = {};
+
+-- Track an action that becomes usable by itself, without knowing it with an aura
+-- If the action is triggered by an aura, it will already activate during buff
+-- The spellID is taken from the aura's table
+-- @param auraID name of the aura registered to SAO.RegisterAura
+function SAO.RegisterCounter(self, auraID)
+    local aura = self.RegisteredAurasByName[auraID];
+    local spellID = select(3,unpack(aura));
+    self.ActivableCounters[spellID] = auraID;
+end
+
+-- Check if an action counter became either activated or deactivated
+function SAO.CheckCounterAction(self, spellID, auraID)
+    local start, duration, enabled, modRate = GetSpellCooldown(spellID);
+    if (type(start) ~= "number") then
+        -- Spell not available
+        return;
+    end
+
+    local aura = self.RegisteredAurasByName[auraID];
+    if (not aura) then
+        -- Unknown aura. Should never happen.
+        return;
+    end
+
+    local isCounterUsable = IsUsableSpell(spellID);
+    local counterMustBeActivated = isCounterUsable and start == 0;
+
+    if (not self.ActivatedCounters[spellID] and counterMustBeActivated) then
+        -- Counter triggered but not shown yet: just do it!
+        self.ActivatedCounters[spellID] = true;
+        self:ActivateOverlay(select(2, aura));
+        self:AddGlow(spellID, {spellID}); -- Same spell ID, because there is no 'aura'
+    elseif (self.ActivatedCounters[spellID] and not counterMustBeActivated) then
+        -- Counter not triggered but still shown: hide it
+        self.ActivatedCounters[spellID] = nil;
+        self:DeactivateOverlay(spellID);
+        self:RemoveGlow(spellID);
+    end
+
+    if (isCounterUsable and start > 0) then
+        -- Counter could be usable, but CD prevents us to: try again in a few seconds
+        local endTime = start+duration;
+
+        if (not self.CounterRetryTimers[spellID] or self.CounterRetryTimers[spellID].endTime ~= endTime) then
+            if (self.CounterRetryTimers[spellID]) then
+                self.CounterRetryTimers[spellID]:Cancel();
+            end
+
+            local remainingTime = endTime-GetTime();
+            local delta = 0.05; -- Add a small delay to account for lags and whatnot
+            local retryFunc = function() self:CheckCounterAction(spellID, auraID); end;
+            self.CounterRetryTimers[spellID] = C_Timer.NewTimer(remainingTime+delta, retryFunc);
+            self.CounterRetryTimers[spellID].endTime = endTime;
+        end
+    end
+end
+
+function SAO.CheckAllCounterActions(self)
+    for spellID, auraID in pairs(self.ActivableCounters) do
+        self:CheckCounterAction(spellID, auraID);
+    end
+end

--- a/counter.lua
+++ b/counter.lua
@@ -1,8 +1,9 @@
 local AddonName, SAO = ...
 
--- List of spell IDs of actions that can trigger as 'counter'
--- key = spellID, value = auraID
-SAO.ActivableCounters = {};
+-- List of spell names or IDs of actions that can trigger as 'counter'
+-- key = spellName / spellID, value = auraID
+SAO.ActivableCountersByName = {};
+SAO.ActivableCountersBySpellID = {};
 
 -- List of spell IDs currently
 -- key = spellID, value = true
@@ -25,11 +26,12 @@ function SAO.RegisterCounter(self, auraID)
     local glowIDs = select(11,unpack(aura));
     for _, glowID in ipairs(glowIDs or {}) do
         if (type(glowID) == "number") then
-            self.ActivableCounters[glowID] = auraID;
+            self.ActivableCountersBySpellID[glowID] = auraID;
         elseif (type(glowID) == "string") then
+            self.ActivableCountersByName[glowID] = auraID;
             local glowSpellIDs = self:GetSpellIDsByName(glowID);
             for _, glowSpellID in ipairs(glowSpellIDs) do
-                self.ActivableCounters[glowSpellID] = auraID;
+                self.ActivableCountersBySpellID[glowSpellID] = auraID;
             end
         end
     end
@@ -83,7 +85,7 @@ function SAO.CheckCounterAction(self, spellID, auraID)
 end
 
 function SAO.CheckAllCounterActions(self)
-    for spellID, auraID in pairs(self.ActivableCounters) do
+    for spellID, auraID in pairs(self.ActivableCountersBySpellID) do
         self:CheckCounterAction(spellID, auraID);
     end
 end

--- a/events.lua
+++ b/events.lua
@@ -77,6 +77,10 @@ function SAO.COMBAT_LOG_EVENT_UNFILTERED(self, ...)
     end
 end
 
+function SAO.SPELL_UPDATE_USABLE(self, ...)
+    self:CheckAllCounterActions();
+end
+
 -- Specific spellbook update
 function SAO.SPELLS_CHANGED(self, ...)
     for glowID, _ in pairs(self.RegisteredGlowSpellNames) do

--- a/events.lua
+++ b/events.lua
@@ -77,6 +77,13 @@ function SAO.COMBAT_LOG_EVENT_UNFILTERED(self, ...)
     end
 end
 
+-- Specific spellbook update
+function SAO.SPELLS_CHANGED(self, ...)
+    for glowID, _ in pairs(self.RegisteredGlowSpellNames) do
+        self:RefreshSpellIDsByName(glowID, true);
+    end
+end
+
 -- Specific spell learned
 function SAO.LEARNED_SPELL_IN_TAB(self, ...)
     local spellID, skillInfoIndex, isGuildPerkSpell = ...;

--- a/events.lua
+++ b/events.lua
@@ -77,6 +77,12 @@ function SAO.COMBAT_LOG_EVENT_UNFILTERED(self, ...)
     end
 end
 
+-- Specific spell learned
+function SAO.LEARNED_SPELL_IN_TAB(self, ...)
+    local spellID, skillInfoIndex, isGuildPerkSpell = ...;
+    self:LearnNewSpell(spellID);
+end
+
 -- Event receiver
 function SAO.OnEvent(self, event, ...)
     if self[event] then

--- a/glow.lua
+++ b/glow.lua
@@ -17,6 +17,34 @@ SAO.DormantActionButtons = {}
 -- The list will change each time an overlay is triggered with a glowing effect
 SAO.GlowingSpells = {}
 
+-- List of spell IDs that should be tracked to glow action buttons
+-- The spell ID may differ from the spell ID for the corresponding aura
+-- key = glowID (= spell ID/name of the glowing spell), value = true
+-- The lists should be setup at start, based on the player class
+SAO.RegisteredGlowSpellIDs = {}
+
+-- List of spell names that should be tracked to glow action buttons
+-- This helps to fill RegisteredGlowSpellIDs e.g., when a spell is learned
+SAO.RegisteredGlowSpellNames = {}
+
+-- Register a list of glow ID
+-- Each ID is either a numeric value (spellID) or a string (spellName)
+function SAO.RegisterGlowIDs(self, glowIDs)
+    for _, glowID in ipairs(glowIDs or {}) do
+        if (type(glowID) == "number") then
+            self.RegisteredGlowSpellIDs[glowID] = true;
+        elseif (type(glowID) == "string") then
+            if (not SAO.RegisteredGlowSpellNames[glowID]) then
+                SAO.RegisteredGlowSpellNames[glowID] = true;
+                local glowSpellIDs = self:GetSpellIDsByName(glowID);
+                for _, glowSpellID in ipairs(glowSpellIDs) do
+                    self.RegisteredGlowSpellIDs[glowSpellID] = true;
+                end
+            end
+        end
+    end
+end
+
 -- An action button has been updated
 -- Check its old/new action and old/new spell ID, and put it in appropriate lists
 -- If forceRefresh is true, refresh even if old spell ID and new spell ID are identical

--- a/overlay.lua
+++ b/overlay.lua
@@ -12,8 +12,10 @@ end
 
 -- Add or refresh an overlay
 function SAO.ActivateOverlay(self, stacks, spellID, texture, positions, scale, r, g, b, autoPulse, forcePulsePlay)
-    self.ActiveOverlays[spellID] = stacks;
-    self.ShowAllOverlays(self.Frame, spellID, texture, positions, scale, r, g, b, autoPulse, forcePulsePlay);
+    if (texture) then
+        self.ActiveOverlays[spellID] = stacks;
+        self.ShowAllOverlays(self.Frame, spellID, texture, positions, scale, r, g, b, autoPulse, forcePulsePlay);
+    end
 end
 
 -- Remove an overlay

--- a/spell.lua
+++ b/spell.lua
@@ -1,0 +1,49 @@
+local AddonName, SAO = ...
+
+-- List of spell IDs sharing the same name
+-- key = spell name, value = list of spell IDs
+-- The list is a cache of calls to GetSpellIDsByName
+-- The list will evolve automatically when the player learns new spells
+SAO.SpellIDsByName = {}
+
+-- Returns the list of spell IDs for a given name
+-- Returns an empty list {} if the spell is not found in the spellbook
+function SAO.GetSpellIDsByName(self, name)
+    local cached = self.SpellIDsByName[name];
+    if (cached) then
+        return cached;
+    end
+
+    local homonyms = self.GetHomonymSpellIDs(name);
+    self.SpellIDsByName[name] = homonyms;
+    return homonyms;
+end
+
+-- Update the spell cache when a new spell is learned
+function SAO.LearnNewSpell(self, spellID)
+    local name = GetSpellInfo(spellID);
+    if (not name) then
+        return;
+    end
+
+    local cached = self.SpellIDsByName[name];
+    if (not cached) then
+        -- Not interested in untracked spells
+        return;
+    end
+
+    for _, id in ipairs(cached) do
+        if (id == spellID) then
+            -- Spell ID already cached
+            return
+        end
+    end
+
+    -- At this point, the spell ID is not cached yet, just do it!
+    table.insert(self.SpellIDsByName[name], spellID);
+
+    -- Also update RegisteredGlowSpellIDs if the name the tracked
+    if (self.RegisteredGlowSpellNames[name]) then
+        self.RegisteredGlowSpellIDs[spellID] = true;
+    end
+end

--- a/spell.lua
+++ b/spell.lua
@@ -14,9 +14,26 @@ function SAO.GetSpellIDsByName(self, name)
         return cached;
     end
 
+    self:RefreshSpellIDsByName(name);
+    return self.SpellIDsByName[name];
+end
+
+-- Force refresh the list of spell IDs for a given name by looking at the spellbook
+-- The cache is updated in the process
+-- If awaken is true, spellIDs are also added to RegisteredGlowSpellIDs
+function SAO.RefreshSpellIDsByName(self, name, awaken)
     local homonyms = self.GetHomonymSpellIDs(name);
     self.SpellIDsByName[name] = homonyms;
-    return homonyms;
+
+    -- Awake dormant buttons associated to these spellIDs
+    if (awaken) then
+        for _, spellID in ipairs(homonyms) do
+            if (not self.RegisteredGlowSpellIDs[spellID]) then
+                self.RegisteredGlowSpellIDs[spellID] = true;
+                self:AwakeButtonsBySpellID(spellID);
+            end
+        end
+    end
 end
 
 -- Update the spell cache when a new spell is learned
@@ -45,5 +62,8 @@ function SAO.LearnNewSpell(self, spellID)
     -- Also update RegisteredGlowSpellIDs if the name the tracked
     if (self.RegisteredGlowSpellNames[name]) then
         self.RegisteredGlowSpellIDs[spellID] = true;
+
+        -- Awaken dormant buttons associated to this spellID
+        self:AwakeButtonsBySpellID(spellID);
     end
 end

--- a/spell.lua
+++ b/spell.lua
@@ -27,10 +27,19 @@ function SAO.RefreshSpellIDsByName(self, name, awaken)
 
     -- Awake dormant buttons associated to these spellIDs
     if (awaken) then
+        local auraID = self.ActivableCountersByName[name];
+
         for _, spellID in ipairs(homonyms) do
+            -- Glowing Action Buttons (GABs)
             if (not self.RegisteredGlowSpellIDs[spellID]) then
                 self.RegisteredGlowSpellIDs[spellID] = true;
                 self:AwakeButtonsBySpellID(spellID);
+            end
+
+            -- Counters
+            if (auraID and not self.ActivableCountersBySpellID[spellID]) then
+                self.ActivableCountersBySpellID[spellID] = auraID;
+                self:CheckCounterAction(spellID, auraID);
             end
         end
     end
@@ -65,5 +74,14 @@ function SAO.LearnNewSpell(self, spellID)
 
         -- Awaken dormant buttons associated to this spellID
         self:AwakeButtonsBySpellID(spellID);
+    end
+
+    -- Also update ActivableCountersBySpellID if the name the tracked
+    local auraID = self.ActivableCountersByName[name];
+    if (auraID and not self.ActivableCountersBySpellID[spellID]) then
+        self.ActivableCountersBySpellID[spellID] = auraID;
+
+        -- Try to see if action is usable now
+        self:CheckCounterAction(spellID, auraID);
     end
 end

--- a/util.lua
+++ b/util.lua
@@ -51,3 +51,33 @@ function SAO.GetSpellIDByActionSlot(self, actionSlot)
         return GetMacroSpell(id);
     end
 end
+
+-- Utility function to return the list spellIDs for spells in the spellbook matching the same of a given spell
+-- Spells are searched into the *current* spellbook, not through all available spells ever
+-- This means the returned list will be obsolete if e.g. new spells are learned afterwards or if the player re-specs
+-- @param spell Either the spell name (as string) or the spell ID (as number)
+function SAO.GetHomonymSpellIDs(spell)
+    local spellName;
+    if (type(spell) == "string") then
+        spellName = spell;
+    elseif (type(spell) == "number") then
+        spellName = GetSpellInfo(spell);
+    end
+    if (not spellName) then
+        return {};
+    end
+
+    local homonyms = {};
+
+    for tab = 1, GetNumSpellTabs() do
+        local offset, numSlots = select(3, GetSpellTabInfo(tab));
+        for index = offset+1, offset+numSlots do
+            local name, _, id = GetSpellBookItemName(index, BOOKTYPE_SPELL);
+            if (name == spellName) then
+                table.insert(homonyms, id);
+            end
+        end
+    end
+
+    return homonyms;
+end


### PR DESCRIPTION
Generalization of Glowing Action Buttons, mainly to Spell Activation Overlays, but not always:
- many SAOs have a natural tendency to use GABs e.g., Hot Streak (Mage) craves for a glowing Pyroblast button
- a few SAOs can’t really use GABs e.g., Omen of Clarity (Druid) could make all buttons glow, which loses the value of showing "cast this spell"
- sometimes SAOs have nothing to do with GABs e.g., Overpower (Warrior) doesn’t have a SAO but it makes sens to glow the Overpower button