### PR TITLE
Options Panel

### DIFF
--- a/SpellActivationOverlay.lua
+++ b/SpellActivationOverlay.lua
@@ -13,6 +13,9 @@ function SpellActivationOverlay_OnLoad(self)
 	self.overlaysInUse = {};
 	self.unusedOverlays = {};
 
+	self.sizeScale = sizeScale;
+	SpellActivationOverlay_OnChangeScale(self);
+
 	local class = SAO.Class[select(2, UnitClass("player"))];
 	if class then
 		class.Register(SAO);
@@ -38,8 +41,20 @@ function SpellActivationOverlay_OnLoad(self)
 	self:RegisterEvent("PLAYER_REGEN_DISABLED");
 	self:RegisterEvent("SPELLS_CHANGED");
 	self:RegisterEvent("LEARNED_SPELL_IN_TAB");
+end
 	
-	self:SetSize(longSide, longSide)
+function SpellActivationOverlay_OnChangeScale(self)
+	longSide = 256 * self.sizeScale;
+	shortSide = 128 * self.sizeScale;
+	self:SetSize(longSide, longSide);
+
+	-- Also resize existing overlays
+	for _, overlayList in pairs(self.overlaysInUse) do
+		for i=1, #overlayList do
+			local overlay = overlayList[i];
+			overlay:SetGeometry(longSide, shortSide);
+		end
+	end
 end
 
 function SpellActivationOverlay_OnEvent(self, event, ...)
@@ -130,8 +145,6 @@ function SpellActivationOverlay_ShowOverlay(self, spellID, texturePath, position
 	overlay.spellID = spellID;
 	overlay.position = position;
 	
-	overlay:ClearAllPoints();
-	
 	local texLeft, texRight, texTop, texBottom = 0, 1, 0, 1;
 	if ( vFlip ) then
 		texTop, texBottom = 1, 0;
@@ -148,40 +161,47 @@ function SpellActivationOverlay_ShowOverlay(self, spellID, texturePath, position
 		overlay.texture:SetTexCoord(texRight,texTop, texLeft,texTop, texRight,texBottom, texLeft,texBottom);
 	end
 	
+	overlay.SetGeometry = function(self, longSide, shortSide)
+		local parent = self:GetParent();
+
+		self:ClearAllPoints();
+
 	local width, height;
 	if ( position == "CENTER" ) then
 		width, height = longSide, longSide;
-		overlay:SetPoint("CENTER", self, "CENTER", 0, 0);
+			self:SetPoint("CENTER", parent, "CENTER", 0, 0);
 	elseif ( position == "LEFT" ) then
 		width, height = shortSide, longSide;
-		overlay:SetPoint("RIGHT", self, "LEFT", 0, 0);
+			self:SetPoint("RIGHT", parent, "LEFT", 0, 0);
 	elseif ( position == "RIGHT" ) then
 		width, height = shortSide, longSide;
-		overlay:SetPoint("LEFT", self, "RIGHT", 0, 0);
+			self:SetPoint("LEFT", parent, "RIGHT", 0, 0);
 	elseif ( position == "TOP" ) then
 		width, height = longSide, shortSide;
-		overlay:SetPoint("BOTTOM", self, "TOP");
+			self:SetPoint("BOTTOM", parent, "TOP");
 	elseif ( position == "BOTTOM" ) then
 		width, height = longSide, shortSide;
-		overlay:SetPoint("TOP", self, "BOTTOM");
+			self:SetPoint("TOP", parent, "BOTTOM");
 	elseif ( position == "TOPRIGHT" ) then
 		width, height = shortSide, shortSide;
-		overlay:SetPoint("BOTTOMLEFT", self, "TOPRIGHT", 0, 0);
+			self:SetPoint("BOTTOMLEFT", parent, "TOPRIGHT", 0, 0);
 	elseif ( position == "TOPLEFT" ) then
 		width, height = shortSide, shortSide;
-		overlay:SetPoint("BOTTOMRIGHT", self, "TOPLEFT", 0, 0);
+			self:SetPoint("BOTTOMRIGHT", parent, "TOPLEFT", 0, 0);
 	elseif ( position == "BOTTOMRIGHT" ) then
 		width, height = shortSide, shortSide;
-		overlay:SetPoint("TOPLEFT", self, "BOTTOMRIGHT", 0, 0);
+			self:SetPoint("TOPLEFT", parent, "BOTTOMRIGHT", 0, 0);
 	elseif ( position == "BOTTOMLEFT" ) then
 		width, height = shortSide, shortSide;
-		overlay:SetPoint("TOPRIGHT", self, "BOTTOMLEFT", 0, 0);
+			self:SetPoint("TOPRIGHT", parent, "BOTTOMLEFT", 0, 0);
 	else
 		--GMError("Unknown SpellActivationOverlay position: "..tostring(position));
 		return;
 	end
 	
-	overlay:SetSize(width * scale, height * scale);
+		self:SetSize(width * scale, height * scale);
+	end
+	overlay:SetGeometry(longSide, shortSide);
 	
 	overlay.texture:SetTexture(texturePath);
 	overlay.texture:SetVertexColor(r / 255, g / 255, b / 255);

--- a/SpellActivationOverlay.lua
+++ b/SpellActivationOverlay.lua
@@ -43,7 +43,7 @@ function SpellActivationOverlay_OnLoad(self)
 	self:RegisterEvent("SPELLS_CHANGED");
 	self:RegisterEvent("LEARNED_SPELL_IN_TAB");
 end
-	
+
 function SpellActivationOverlay_OnChangeGeometry(self)
 	-- Ignores self.scale because it should be used to scale alerts, not core
 	local newSize = 256 * sizeScale + self.offset;
@@ -81,13 +81,13 @@ function SpellActivationOverlay_OnEvent(self, event, ...)
 		end
 	end]]
 	if ( not self.disableDimOutOfCombat ) then
-	if ( event == "PLAYER_REGEN_DISABLED" ) then
-		self.combatAnimOut:Stop();	--In case we're in the process of animating this out.
-		self.combatAnimIn:Play();
-	elseif ( event == "PLAYER_REGEN_ENABLED" ) then
-		self.combatAnimIn:Stop();	--In case we're in the process of animating this out.
-		self.combatAnimOut:Play();
-	end
+		if ( event == "PLAYER_REGEN_DISABLED" ) then
+			self.combatAnimOut:Stop();	--In case we're in the process of animating this out.
+			self.combatAnimIn:Play();
+		elseif ( event == "PLAYER_REGEN_ENABLED" ) then
+			self.combatAnimIn:Stop();	--In case we're in the process of animating this out.
+			self.combatAnimOut:Play();
+		end
 	end
 	if ( event ) then
 		SAO:OnEvent(event, ...);
@@ -166,45 +166,45 @@ function SpellActivationOverlay_ShowOverlay(self, spellID, texturePath, position
 	else
 		overlay.texture:SetTexCoord(texRight,texTop, texLeft,texTop, texRight,texBottom, texLeft,texBottom);
 	end
-	
+
 	overlay.SetGeometry = function(self, longSide, shortSide)
 		local parent = self:GetParent();
 
 		self:ClearAllPoints();
 
-	local width, height;
-	if ( position == "CENTER" ) then
-		width, height = longSide, longSide;
+		local width, height;
+		if ( position == "CENTER" ) then
+			width, height = longSide, longSide;
 			self:SetPoint("CENTER", parent, "CENTER", 0, 0);
-	elseif ( position == "LEFT" ) then
-		width, height = shortSide, longSide;
+		elseif ( position == "LEFT" ) then
+			width, height = shortSide, longSide;
 			self:SetPoint("RIGHT", parent, "LEFT", 0, 0);
-	elseif ( position == "RIGHT" ) then
-		width, height = shortSide, longSide;
+		elseif ( position == "RIGHT" ) then
+			width, height = shortSide, longSide;
 			self:SetPoint("LEFT", parent, "RIGHT", 0, 0);
-	elseif ( position == "TOP" ) then
-		width, height = longSide, shortSide;
+		elseif ( position == "TOP" ) then
+			width, height = longSide, shortSide;
 			self:SetPoint("BOTTOM", parent, "TOP");
-	elseif ( position == "BOTTOM" ) then
-		width, height = longSide, shortSide;
+		elseif ( position == "BOTTOM" ) then
+			width, height = longSide, shortSide;
 			self:SetPoint("TOP", parent, "BOTTOM");
-	elseif ( position == "TOPRIGHT" ) then
-		width, height = shortSide, shortSide;
+		elseif ( position == "TOPRIGHT" ) then
+			width, height = shortSide, shortSide;
 			self:SetPoint("BOTTOMLEFT", parent, "TOPRIGHT", 0, 0);
-	elseif ( position == "TOPLEFT" ) then
-		width, height = shortSide, shortSide;
+		elseif ( position == "TOPLEFT" ) then
+			width, height = shortSide, shortSide;
 			self:SetPoint("BOTTOMRIGHT", parent, "TOPLEFT", 0, 0);
-	elseif ( position == "BOTTOMRIGHT" ) then
-		width, height = shortSide, shortSide;
+		elseif ( position == "BOTTOMRIGHT" ) then
+			width, height = shortSide, shortSide;
 			self:SetPoint("TOPLEFT", parent, "BOTTOMRIGHT", 0, 0);
-	elseif ( position == "BOTTOMLEFT" ) then
-		width, height = shortSide, shortSide;
+		elseif ( position == "BOTTOMLEFT" ) then
+			width, height = shortSide, shortSide;
 			self:SetPoint("TOPRIGHT", parent, "BOTTOMLEFT", 0, 0);
-	else
-		--GMError("Unknown SpellActivationOverlay position: "..tostring(position));
-		return;
-	end
-	
+		else
+			--GMError("Unknown SpellActivationOverlay position: "..tostring(position));
+			return;
+		end
+
 		self:SetSize(width * scale, height * scale);
 	end
 	overlay:SetGeometry(longSide, shortSide);

--- a/SpellActivationOverlay.lua
+++ b/SpellActivationOverlay.lua
@@ -13,8 +13,9 @@ function SpellActivationOverlay_OnLoad(self)
 	self.overlaysInUse = {};
 	self.unusedOverlays = {};
 
-	self.sizeScale = sizeScale;
-	SpellActivationOverlay_OnChangeScale(self);
+	self.offset = 0;
+	self.scale = 1;
+	SpellActivationOverlay_OnChangeGeometry(self);
 
 	local class = SAO.Class[select(2, UnitClass("player"))];
 	if class then
@@ -43,12 +44,15 @@ function SpellActivationOverlay_OnLoad(self)
 	self:RegisterEvent("LEARNED_SPELL_IN_TAB");
 end
 	
-function SpellActivationOverlay_OnChangeScale(self)
-	longSide = 256 * self.sizeScale;
-	shortSide = 128 * self.sizeScale;
-	self:SetSize(longSide, longSide);
+function SpellActivationOverlay_OnChangeGeometry(self)
+	-- Ignores self.scale because it should be used to scale alerts, not core
+	local newSize = 256 * sizeScale + self.offset;
+	-- Resize the parent instead of self because the parent is the one bearing the Size element
+	self:GetParent():SetSize(newSize, newSize);
 
-	-- Also resize existing overlays
+	-- Resize existing overlays and prepare variables for future overlays
+	longSide = 256 * sizeScale * self.scale;
+	shortSide = 128 * sizeScale * self.scale;
 	for _, overlayList in pairs(self.overlaysInUse) do
 		for i=1, #overlayList do
 			local overlay = overlayList[i];

--- a/SpellActivationOverlay.lua
+++ b/SpellActivationOverlay.lua
@@ -80,12 +80,14 @@ function SpellActivationOverlay_OnEvent(self, event, ...)
 			SpellActivationOverlay_HideAllOverlays(self);
 		end
 	end]]
+	if ( not self.disableDimOutOfCombat ) then
 	if ( event == "PLAYER_REGEN_DISABLED" ) then
 		self.combatAnimOut:Stop();	--In case we're in the process of animating this out.
 		self.combatAnimIn:Play();
 	elseif ( event == "PLAYER_REGEN_ENABLED" ) then
 		self.combatAnimIn:Stop();	--In case we're in the process of animating this out.
 		self.combatAnimOut:Play();
+	end
 	end
 	if ( event ) then
 		SAO:OnEvent(event, ...);

--- a/SpellActivationOverlay.lua
+++ b/SpellActivationOverlay.lua
@@ -147,6 +147,10 @@ function SpellActivationOverlay_ShowAllOverlays(self, spellID, texturePath, posi
 end
 
 function SpellActivationOverlay_ShowOverlay(self, spellID, texturePath, position, scale, r, g, b, vFlip, hFlip, cw, autoPulse, forcePulsePlay)
+	if (not SpellActivationOverlayDB.alert.enabled) then
+		return
+	end
+
 	local overlay = SpellActivationOverlay_GetOverlay(self, spellID, position);
 	overlay.spellID = spellID;
 	overlay.position = position;

--- a/SpellActivationOverlay.toc
+++ b/SpellActivationOverlay.toc
@@ -1,8 +1,9 @@
 ## Interface: 30400
-## Title: SpellActivationOverlay |cffa2f3ff0.5.0|r
+## Title: SpellActivationOverlay |cffa2f3ff0.6.0|r
 ## Notes: Mimic Spell Activation Overlays from Retail
 ## Author: Vinny
-## Version: 0.5.0
+## Version: 0.6.0
+## SavedVariables: SpellActivationOverlayDB
 
 # SpellActivationOverlay.lua, SpellActivationOverlay.xml and all textures
 # were created by Blizzard Entertainment, Inc.
@@ -28,6 +29,10 @@ classes\rogue.lua
 classes\shaman.lua
 classes\warlock.lua
 classes\warrior.lua
+
+options\db.lua
+options\InterfaceOptionsPanels.lua
+options\InterfaceOptionsPanels.xml
 
 SpellActivationOverlay.lua
 SpellActivationOverlay.xml

--- a/SpellActivationOverlay.toc
+++ b/SpellActivationOverlay.toc
@@ -31,6 +31,7 @@ classes\warlock.lua
 classes\warrior.lua
 
 options\db.lua
+options\variables.lua
 options\InterfaceOptionsPanels.lua
 options\InterfaceOptionsPanels.xml
 

--- a/SpellActivationOverlay.xml
+++ b/SpellActivationOverlay.xml
@@ -31,28 +31,36 @@
 			<OnShow function="SpellActivationOverlayTexture_OnShow"/>
 		</Scripts>
 	</Frame>
-	<Frame name="SpellActivationOverlayFrame" parent="UIParent" alpha="0.5">
+	<Frame name="SpellActivationOverlayContainerFrame" parent="UIParent">
 		<Size x="256" y="256"/>
 		<Anchors>
 			<Anchor point="CENTER"/>
 		</Anchors>
-		<Animations>
-			<AnimationGroup name="$enteringCombatAnim" parentKey="combatAnimIn">
-				<Alpha fromAlpha="0.5" toAlpha="1" duration="0.1"/>
+		<Frames>
+			<Frame name="SpellActivationOverlayFrame" alpha="0.5">
+				<Anchors>
+					<Anchor point="TOPLEFT"/>
+					<Anchor point="BOTTOMRIGHT"/>
+				</Anchors>
+				<Animations>
+					<AnimationGroup name="$enteringCombatAnim" parentKey="combatAnimIn">
+						<Alpha fromAlpha="0.5" toAlpha="1" duration="0.1"/>
+						<Scripts>
+							<OnFinished function="SpellActivationOverlayFrame_OnFadeInFinished"/>
+						</Scripts>
+					</AnimationGroup>
+					<AnimationGroup name="$leavingCombatAnim" parentKey="combatAnimOut">
+						<Alpha fromAlpha="1" toAlpha="0.5" duration="0.2"/>
+						<Scripts>
+							<OnFinished function="SpellActivationOverlayFrame_OnFadeOutFinished"/>
+						</Scripts>
+					</AnimationGroup>
+				</Animations>
 				<Scripts>
-					<OnFinished function="SpellActivationOverlayFrame_OnFadeInFinished"/>
+					<OnLoad function="SpellActivationOverlay_OnLoad"/>
+					<OnEvent function="SpellActivationOverlay_OnEvent"/>
 				</Scripts>
-			</AnimationGroup>
-			<AnimationGroup name="$leavingCombatAnim" parentKey="combatAnimOut">
-				<Alpha fromAlpha="1" toAlpha="0.5" duration="0.2"/>
-				<Scripts>
-					<OnFinished function="SpellActivationOverlayFrame_OnFadeOutFinished"/>
-				</Scripts>
-			</AnimationGroup>
-		</Animations>
-		<Scripts>
-			<OnLoad function="SpellActivationOverlay_OnLoad"/>
-			<OnEvent function="SpellActivationOverlay_OnEvent"/>
-		</Scripts>
+			</Frame>
+		</Frames>
 	</Frame>
 </Ui>

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,9 @@
 
 - After extensive testing, SpellActivationOverlay now leaves its Beta phase!
 - Options Panel, available from Interface > AddOns > SpellActivationOverlay
-- Current options are: Spell Alert opacity, and Glowing Buttons on/off
+- Options for Spell Alerts: opacity, scale factor, offset
+- Options for Glowing Buttons: on/off
+- A "Toggle Test" button displays fake Spell Alerts for testing interactively
 
 #### v0.5.0-beta (2022-08-31)
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 ## SpellActivationOverlay Changelog
 
+#### v0.6.0 (2022-09-xx)
+
+- After extensive testing, SpellActivationOverlay now leaves its Beta phase!
+- Options Panel, available from Interface > AddOns > SpellActivationOverlay
+- Current options are: Spell Alert opacity, and Glowing Buttons on/off
+
 #### v0.5.0-beta (2022-08-31)
 
 SpellActivationOverlay now has a Discord server!

--- a/components/glow.lua
+++ b/components/glow.lua
@@ -114,7 +114,9 @@ function SAO.UpdateActionButton(self, button, forceRefresh)
     local mustGlow = newGlowID and (self.GlowingSpells[newGlowID] ~= nil);
 
     if (not wasGlowing and mustGlow) then
-        ActionButton_ShowOverlayGlow(button);
+        if (not SpellActivationOverlayDB.glow or SpellActivationOverlayDB.glow.enabled) then
+            ActionButton_ShowOverlayGlow(button);
+        end
     elseif (wasGlowing and not mustGlow) then
         ActionButton_HideOverlayGlow(button);
     end
@@ -160,7 +162,9 @@ function SAO.AddGlowNumber(self, spellID, glowID)
     else
         self.GlowingSpells[glowID] = { [spellID] = true };
         for _, frame in pairs(actionButtons or {}) do
-            ActionButton_ShowOverlayGlow(frame);
+            if (not SpellActivationOverlayDB.glow or SpellActivationOverlayDB.glow.enabled) then
+                ActionButton_ShowOverlayGlow(frame);
+            end
         end
     end
 end

--- a/options/InterfaceOptionsPanels.lua
+++ b/options/InterfaceOptionsPanels.lua
@@ -1,4 +1,4 @@
-local Addon, SAO = ...
+local AddonName, SAO = ...
 
 function SpellActivationOverlayOptionsPanel_Init(self)
     local opacitySlider = SpellActivationOverlayOptionsPanelSpellAlertOpacitySlider;
@@ -6,32 +6,44 @@ function SpellActivationOverlayOptionsPanel_Init(self)
     _G[opacitySlider:GetName().."Low"]:SetText(OFF);
     opacitySlider:SetMinMaxValues(0, 1);
     opacitySlider:SetValueStep(0.05);
-    opacitySlider:SetValue(SpellActivationOverlayDB.alert.opacity);
 
     local glowingButtonCheckbox = SpellActivationOverlayOptionsPanelGlowingButtons;
     glowingButtonCheckbox.Text:SetText("Glowing Buttons");
-    glowingButtonCheckbox:SetChecked(SpellActivationOverlayDB.glow.enabled);
+
+    -- Hack to apply database variables to UI elements
+    self.cancel();
 end
 
-function SpellActivationOverlayOptionsPanel_OnLoad(self)
-    self.name = Addon;
-
+-- User clicks OK to the options panel
+local function okayFunc(self)
     local opacitySlider = SpellActivationOverlayOptionsPanelSpellAlertOpacitySlider;
-    local glowingButtonCheckbox = SpellActivationOverlayOptionsPanelGlowingButtons;
-
-    self.okay = function(self)
+    if (SpellActivationOverlayDB.alert.opacity ~= opacitySlider:GetValue()) then
         SpellActivationOverlayDB.alert.opacity = opacitySlider:GetValue();
-
-        SpellActivationOverlayDB.glow.enabled = glowingButtonCheckbox:GetChecked();
-
-        -- TODO also apply values in the SAO/GAB engine
+        SAO.ApplySpellAlertOpacity();
     end
 
-    self.cancel = function(self)
+    local glowingButtonCheckbox = SpellActivationOverlayOptionsPanelGlowingButtons;
+    if (SpellActivationOverlayDB.glow.enabled ~= glowingButtonCheckbox:GetChecked()) then
+        SpellActivationOverlayDB.glow.enabled = glowingButtonCheckbox:GetChecked();
+        SAO.ApplyGlowingButtonsToggle();
+    end
+    end
+
+-- User clicked Cancel to the options panel
+local function cancelFunc(self)
+    local opacitySlider = SpellActivationOverlayOptionsPanelSpellAlertOpacitySlider;
         opacitySlider:SetValue(SpellActivationOverlayDB.alert.opacity);
 
+    local glowingButtonCheckbox = SpellActivationOverlayOptionsPanelGlowingButtons;
         glowingButtonCheckbox:SetChecked(SpellActivationOverlayDB.glow.enabled);
     end
 
+function SpellActivationOverlayOptionsPanel_OnLoad(self)
+    self.name = AddonName;
+    self.okay = okayFunc;
+    self.cancel = cancelFunc;
+
     InterfaceOptions_AddCategory(self);
+
+    SAO.OptionsPanel = self;
 end

--- a/options/InterfaceOptionsPanels.lua
+++ b/options/InterfaceOptionsPanels.lua
@@ -18,7 +18,7 @@ function SpellActivationOverlayOptionsPanel_Init(self)
     scaleSlider.Text:SetText("Spell Alert scale");
     _G[scaleSlider:GetName().."Low"]:SetText(SMALL);
     _G[scaleSlider:GetName().."High"]:SetText(LARGE);
-    scaleSlider:SetMinMaxValues(0.5, 2);
+    scaleSlider:SetMinMaxValues(0.25, 2.5);
     scaleSlider:SetValueStep(0.05);
     scaleSlider.initialValue = SpellActivationOverlayDB.alert.scale;
     scaleSlider:SetValue(scaleSlider.initialValue);

--- a/options/InterfaceOptionsPanels.lua
+++ b/options/InterfaceOptionsPanels.lua
@@ -95,26 +95,50 @@ end
 -- User clicked Cancel to the options panel
 local function cancelFunc(self)
     local opacitySlider = SpellActivationOverlayOptionsPanelSpellAlertOpacitySlider;
-    opacitySlider:SetValue(opacitySlider.initialValue);
-    if (SpellActivationOverlayDB.alert.opacity ~= opacitySlider.initialValue) then
-        SpellActivationOverlayDB.alert.opacity = opacitySlider.initialValue;
-        SpellActivationOverlayDB.alert.enabled = opacitySlider.initialValue > 0;
+    local scaleSlider = SpellActivationOverlayOptionsPanelSpellAlertScaleSlider;
+    local offsetSlider = SpellActivationOverlayOptionsPanelSpellAlertOffsetSlider;
+    local glowingButtonCheckbox = SpellActivationOverlayOptionsPanelGlowingButtons;
+
+    self:applyAll(
+        opacitySlider.initialValue,
+        scaleSlider.initialValue,
+        offsetSlider.initialValue,
+        glowingButtonCheckbox.initialValue
+    );
+end
+
+-- User reset settings to default values
+local function defaultFunc(self)
+    self:applyAll(
+        1, -- opacity
+        1, -- scale
+        0, -- offset
+        true -- glow
+    );
+end
+
+local function applyAllFunc(self, opacityValue, scaleValue, offsetValue, isGlowEnabled)
+    local opacitySlider = SpellActivationOverlayOptionsPanelSpellAlertOpacitySlider;
+    opacitySlider:SetValue(opacityValue);
+    if (SpellActivationOverlayDB.alert.opacity ~= opacityValue) then
+        SpellActivationOverlayDB.alert.opacity = opacityValue;
+        SpellActivationOverlayDB.alert.enabled = opacityValue > 0;
         SAO:ApplySpellAlertOpacity();
     end
 
     local geometryChanged = false;
 
     local scaleSlider = SpellActivationOverlayOptionsPanelSpellAlertScaleSlider;
-    scaleSlider:SetValue(scaleSlider.initialValue);
-    if (SpellActivationOverlayDB.alert.scale ~= scaleSlider.initialValue) then
-        SpellActivationOverlayDB.alert.scale = scaleSlider.initialValue;
+    scaleSlider:SetValue(scaleValue);
+    if (SpellActivationOverlayDB.alert.scale ~= scaleValue) then
+        SpellActivationOverlayDB.alert.scale = scaleValue;
         geometryChanged = true;
     end
 
     local offsetSlider = SpellActivationOverlayOptionsPanelSpellAlertOffsetSlider;
-    offsetSlider:SetValue(offsetSlider.initialValue);
-    if (SpellActivationOverlayDB.alert.offset ~= offsetSlider.initialValue) then
-        SpellActivationOverlayDB.alert.offset = offsetSlider.initialValue;
+    offsetSlider:SetValue(offsetValue);
+    if (SpellActivationOverlayDB.alert.offset ~= offsetValue) then
+        SpellActivationOverlayDB.alert.offset = offsetValue;
         geometryChanged = true;
     end
 
@@ -127,18 +151,19 @@ local function cancelFunc(self)
     testButton:SetEnabled(SpellActivationOverlayDB.alert.enabled);
 
     local glowingButtonCheckbox = SpellActivationOverlayOptionsPanelGlowingButtons;
-    glowingButtonCheckbox:SetChecked(glowingButtonCheckbox.initialValue);
-    -- Not necessary because this option is non-interactive
-    --if (SpellActivationOverlayDB.glow.enabled ~= glowingButtonCheckbox.initialValue) then
-    --    SpellActivationOverlayDB.glow.enabled = glowingButtonCheckbox.initialValue;
-    --    SAO:ApplyGlowingButtonsToggle();
-    --end
+    glowingButtonCheckbox:SetChecked(isGlowEnabled);
+    if (SpellActivationOverlayDB.glow.enabled ~= isGlowEnabled) then
+        SpellActivationOverlayDB.glow.enabled = isGlowEnabled;
+        SAO:ApplyGlowingButtonsToggle();
     end
+end
 
 function SpellActivationOverlayOptionsPanel_OnLoad(self)
     self.name = AddonName;
     self.okay = okayFunc;
     self.cancel = cancelFunc;
+    self.default = defaultFunc;
+    self.applyAll = applyAllFunc; -- not a callback used by Blizzard's InterfaceOptions_AddCategory, but used by us
 
     InterfaceOptions_AddCategory(self);
 

--- a/options/InterfaceOptionsPanels.lua
+++ b/options/InterfaceOptionsPanels.lua
@@ -7,6 +7,20 @@ function SpellActivationOverlayOptionsPanel_Init(self)
     opacitySlider:SetMinMaxValues(0, 1);
     opacitySlider:SetValueStep(0.05);
 
+    local scaleSlider = SpellActivationOverlayOptionsPanelSpellAlertScaleSlider;
+    scaleSlider.Text:SetText("Spell Alert scale");
+    _G[scaleSlider:GetName().."Low"]:SetText(SMALL);
+    _G[scaleSlider:GetName().."High"]:SetText(LARGE);
+    scaleSlider:SetMinMaxValues(0.5, 2);
+    scaleSlider:SetValueStep(0.05);
+
+    local offsetSlider = SpellActivationOverlayOptionsPanelSpellAlertOffsetSlider;
+    offsetSlider.Text:SetText("Spell Alert offset");
+    _G[offsetSlider:GetName().."Low"]:SetText(NEAR);
+    _G[offsetSlider:GetName().."High"]:SetText(FAR);
+    offsetSlider:SetMinMaxValues(-200, 400);
+    offsetSlider:SetValueStep(20);
+
     local glowingButtonCheckbox = SpellActivationOverlayOptionsPanelGlowingButtons;
     glowingButtonCheckbox.Text:SetText("Glowing Buttons");
 
@@ -22,6 +36,24 @@ local function okayFunc(self)
         SAO.ApplySpellAlertOpacity();
     end
 
+    local geometryChanged = false;
+
+    local scaleSlider = SpellActivationOverlayOptionsPanelSpellAlertScaleSlider;
+    if (SpellActivationOverlayDB.alert.scale ~= scaleSlider:GetValue()) then
+        SpellActivationOverlayDB.alert.scale = scaleSlider:GetValue();
+        geometryChanged = true;
+    end
+
+    local offsetSlider = SpellActivationOverlayOptionsPanelSpellAlertOffsetSlider;
+    if (SpellActivationOverlayDB.alert.offset ~= offsetSlider:GetValue()) then
+        SpellActivationOverlayDB.alert.offset = offsetSlider:GetValue();
+        geometryChanged = true;
+    end
+
+    if (geometryChanged) then
+        SAO.ApplySpellAlertGeometry();
+    end
+
     local glowingButtonCheckbox = SpellActivationOverlayOptionsPanelGlowingButtons;
     if (SpellActivationOverlayDB.glow.enabled ~= glowingButtonCheckbox:GetChecked()) then
         SpellActivationOverlayDB.glow.enabled = glowingButtonCheckbox:GetChecked();
@@ -33,6 +65,12 @@ local function okayFunc(self)
 local function cancelFunc(self)
     local opacitySlider = SpellActivationOverlayOptionsPanelSpellAlertOpacitySlider;
         opacitySlider:SetValue(SpellActivationOverlayDB.alert.opacity);
+
+    local scaleSlider = SpellActivationOverlayOptionsPanelSpellAlertScaleSlider;
+    scaleSlider:SetValue(SpellActivationOverlayDB.alert.scale);
+
+    local offsetSlider = SpellActivationOverlayOptionsPanelSpellAlertOffsetSlider;
+    offsetSlider:SetValue(SpellActivationOverlayDB.alert.offset);
 
     local glowingButtonCheckbox = SpellActivationOverlayOptionsPanelGlowingButtons;
         glowingButtonCheckbox:SetChecked(SpellActivationOverlayDB.glow.enabled);

--- a/options/InterfaceOptionsPanels.lua
+++ b/options/InterfaceOptionsPanels.lua
@@ -2,7 +2,8 @@ local Addon, SAO = ...
 
 function SpellActivationOverlayOptionsPanel_Init(self)
     local opacitySlider = SpellActivationOverlayOptionsPanelSpellAlertOpacitySlider;
-    opacitySlider.Text:SetText("SPELL_ALERT_OPACITY");
+    opacitySlider.Text:SetText("Spell Alert opacity");
+    _G[opacitySlider:GetName().."Low"]:SetText(OFF);
     opacitySlider:SetMinMaxValues(0, 1);
     opacitySlider:SetValueStep(0.05);
     opacitySlider:SetValue(SpellActivationOverlayDB.alert.opacity);

--- a/options/InterfaceOptionsPanels.lua
+++ b/options/InterfaceOptionsPanels.lua
@@ -49,12 +49,20 @@ function SpellActivationOverlayOptionsPanel_Init(self)
             self.isTesting = true;
             SAO:ActivateOverlay(0, self.fakeSpellID, SAO.TexName["imp_empowerment"], "Left + Right (Flipped)", 1, 255, 255, 255, false);
             SAO:ActivateOverlay(0, self.fakeSpellID, SAO.TexName["brain_freeze"], "Top", 1, 255, 255, 255, false);
+            -- Hack the frame to force full opacity even when out of combat
+            SpellActivationOverlayFrame.disableDimOutOfCombat = true;
+            SpellActivationOverlayFrame:SetAlpha(1);
         end
     end
     testButton.StopTest = function(self)
         if (self.isTesting) then
             self.isTesting = false;
             SAO:DeactivateOverlay(self.fakeSpellID);
+            -- Undo hack
+            SpellActivationOverlayFrame.disableDimOutOfCombat = nil;
+            if (not InCombatLockdown()) then
+                SpellActivationOverlayFrame.combatAnimOut:Play();
+            end
         end
     end
     testButton:SetEnabled(SpellActivationOverlayDB.alert.enabled);

--- a/options/InterfaceOptionsPanels.lua
+++ b/options/InterfaceOptionsPanels.lua
@@ -21,6 +21,24 @@ function SpellActivationOverlayOptionsPanel_Init(self)
     offsetSlider:SetMinMaxValues(-200, 400);
     offsetSlider:SetValueStep(20);
 
+    local testButton = SpellActivationOverlayOptionsPanelSpellAlertTestButton;
+    testButton:SetText("Toggle Test");
+    testButton.fakeSpellID = 42;
+    testButton.isTesting = false;
+    testButton.StartTest = function(self)
+        if (not self.isTesting) then
+            self.isTesting = true;
+            SAO:ActivateOverlay(0, self.fakeSpellID, SAO.TexName["imp_empowerment"], "Left + Right (Flipped)", 1, 255, 255, 255, false);
+            SAO:ActivateOverlay(0, self.fakeSpellID, SAO.TexName["brain_freeze"], "Top", 1, 255, 255, 255, false);
+        end
+    end
+    testButton.StopTest = function(self)
+        if (self.isTesting) then
+            self.isTesting = false;
+            SAO:DeactivateOverlay(self.fakeSpellID);
+        end
+    end
+
     local glowingButtonCheckbox = SpellActivationOverlayOptionsPanelGlowingButtons;
     glowingButtonCheckbox.Text:SetText("Glowing Buttons");
 

--- a/options/InterfaceOptionsPanels.lua
+++ b/options/InterfaceOptionsPanels.lua
@@ -1,0 +1,36 @@
+local Addon, SAO = ...
+
+function SpellActivationOverlayOptionsPanel_Init(self)
+    local opacitySlider = SpellActivationOverlayOptionsPanelSpellAlertOpacitySlider;
+    opacitySlider.Text:SetText("SPELL_ALERT_OPACITY");
+    opacitySlider:SetMinMaxValues(0, 1);
+    opacitySlider:SetValueStep(0.05);
+    opacitySlider:SetValue(SpellActivationOverlayDB.alert.opacity);
+
+    local glowingButtonCheckbox = SpellActivationOverlayOptionsPanelGlowingButtons;
+    glowingButtonCheckbox.Text:SetText("Glowing Buttons");
+    glowingButtonCheckbox:SetChecked(SpellActivationOverlayDB.glow.enabled);
+end
+
+function SpellActivationOverlayOptionsPanel_OnLoad(self)
+    self.name = Addon;
+
+    local opacitySlider = SpellActivationOverlayOptionsPanelSpellAlertOpacitySlider;
+    local glowingButtonCheckbox = SpellActivationOverlayOptionsPanelGlowingButtons;
+
+    self.okay = function(self)
+        SpellActivationOverlayDB.alert.opacity = opacitySlider:GetValue();
+
+        SpellActivationOverlayDB.glow.enabled = glowingButtonCheckbox:GetChecked();
+
+        -- TODO also apply values in the SAO/GAB engine
+    end
+
+    self.cancel = function(self)
+        opacitySlider:SetValue(SpellActivationOverlayDB.alert.opacity);
+
+        glowingButtonCheckbox:SetChecked(SpellActivationOverlayDB.glow.enabled);
+    end
+
+    InterfaceOptions_AddCategory(self);
+end

--- a/options/InterfaceOptionsPanels.xml
+++ b/options/InterfaceOptionsPanels.xml
@@ -26,14 +26,6 @@
           </Anchor>
         </Anchors>
         <Scripts>
-          <OnLoad>
-            self:OnBackdropLoaded();
-            self.SetDisplayValue = self.SetValue;
-            self.SetValue = function (self, value)
-              value = math.floor(value * 100 + 0.5) / 100;
-              self:SetDisplayValue(value);
-            end
-          </OnLoad>
           <OnValueChanged>
             value = math.floor(value * 100 + 0.5) / 100;
             if (value ~= 0) then

--- a/options/InterfaceOptionsPanels.xml
+++ b/options/InterfaceOptionsPanels.xml
@@ -33,6 +33,11 @@
             end
             self.value = value;
             self:SetValue(value);
+
+            if (self.ApplyValueToEngine) then
+              self:ApplyValueToEngine(value);
+            end
+            _G[self:GetParent():GetName().."SpellAlertTestButton"]:SetEnabled(value > 0);
           </OnValueChanged>
         </Scripts>
       </Slider>
@@ -44,6 +49,13 @@
             </Offset>
           </Anchor>
         </Anchors>
+        <Scripts>
+          <OnValueChanged>
+            if (self.ApplyValueToEngine) then
+              self:ApplyValueToEngine(value);
+            end
+          </OnValueChanged>
+        </Scripts>
       </Slider>
       <Slider name="$parentSpellAlertOffsetSlider" inherits="OptionsSliderTemplate">
         <Anchors>
@@ -53,6 +65,13 @@
             </Offset>
           </Anchor>
         </Anchors>
+        <Scripts>
+          <OnValueChanged>
+            if (self.ApplyValueToEngine) then
+              self:ApplyValueToEngine(value);
+            end
+          </OnValueChanged>
+        </Scripts>
       </Slider>
       <Button name="$parentSpellAlertTestButton" inherits="OptionsButtonTemplate">
         <Anchors>

--- a/options/InterfaceOptionsPanels.xml
+++ b/options/InterfaceOptionsPanels.xml
@@ -26,32 +26,13 @@
           </Anchor>
         </Anchors>
         <Scripts>
-          <!-- <OnLoad>
+          <OnLoad>
             self:OnBackdropLoaded();
-            self.Text:SetText("Spell Alert opacity");
-          </OnLoad> -->
-          <!-- <OnLoad>
-            self.type = CONTROLTYPE_SLIDER;
-            self.cvar = "spellActivationOverlayOpacity";
             self.SetDisplayValue = self.SetValue;
-            _G[self:GetName().."Low"]:SetText(OFF);
             self.SetValue = function (self, value)
-print("Slider SetValue", self, value);
               value = math.floor(value * 100 + 0.5) / 100;
               self:SetDisplayValue(value);
-              if (value == 0) then
-                SpellActivationOverlayDB.alert.enabled = false;
-              else
-                SpellActivationOverlayDB.alert.enabled = true;
-              end
-              SpellActivationOverlayFrame:SetAlpha(value);
             end
-            self.GetValue = function(self)
-print("Checkbox GetValue", self, SpellActivationOverlayDB.alert.opacity);
-              return SpellActivationOverlayDB.alert.opacity;
-            end
-            BlizzardOptionsPanel_RegisterControl(self, self:GetParent());
-            self:RegisterEvent("VARIABLES_LOADED");
           </OnLoad>
           <OnValueChanged>
             value = math.floor(value * 100 + 0.5) / 100;
@@ -60,13 +41,7 @@ print("Checkbox GetValue", self, SpellActivationOverlayDB.alert.opacity);
             end
             self.value = value;
             self:SetValue(value);
-            SpellActivationOverlayDB.alert.opacity = value;
           </OnValueChanged>
-          <OnEvent>
-            local value = tonumber(SpellActivationOverlayDB.alert.opacity);
-            value = math.floor(value * 100 + 0.5) / 100;
-            self:SetValue(value);
-          </OnEvent> -->
         </Scripts>
       </Slider>
       <CheckButton name="$parentGlowingButtons" inherits="InterfaceOptionsCheckButtonTemplate">
@@ -78,9 +53,6 @@ print("Checkbox GetValue", self, SpellActivationOverlayDB.alert.opacity);
           </Anchor>
         </Anchors>
         <Scripts>
-          <!-- <OnLoad>
-            self.Text:SetText("Glowing Buttons");
-          </OnLoad> -->
         </Scripts>
       </CheckButton>
     </Frames>

--- a/options/InterfaceOptionsPanels.xml
+++ b/options/InterfaceOptionsPanels.xml
@@ -36,7 +36,7 @@
           </OnValueChanged>
         </Scripts>
       </Slider>
-      <CheckButton name="$parentGlowingButtons" inherits="InterfaceOptionsCheckButtonTemplate">
+      <Slider name="$parentSpellAlertScaleSlider" inherits="OptionsSliderTemplate">
         <Anchors>
           <Anchor point="TOPLEFT" relativeTo="$parentSpellAlertOpacitySlider" relativePoint="BOTTOMLEFT">
             <Offset>
@@ -44,8 +44,24 @@
             </Offset>
           </Anchor>
         </Anchors>
-        <Scripts>
-        </Scripts>
+      </Slider>
+      <Slider name="$parentSpellAlertOffsetSlider" inherits="OptionsSliderTemplate">
+        <Anchors>
+          <Anchor point="TOPLEFT" relativeTo="$parentSpellAlertScaleSlider" relativePoint="BOTTOMLEFT">
+            <Offset>
+              <AbsDimension x="0" y="-32"/>
+            </Offset>
+          </Anchor>
+        </Anchors>
+      </Slider>
+      <CheckButton name="$parentGlowingButtons" inherits="InterfaceOptionsCheckButtonTemplate">
+        <Anchors>
+          <Anchor point="TOPLEFT" relativeTo="$parentSpellAlertOffsetSlider" relativePoint="BOTTOMLEFT">
+            <Offset>
+              <AbsDimension x="-24" y="-32"/>
+            </Offset>
+          </Anchor>
+        </Anchors>
       </CheckButton>
     </Frames>
     <Scripts>

--- a/options/InterfaceOptionsPanels.xml
+++ b/options/InterfaceOptionsPanels.xml
@@ -1,0 +1,92 @@
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/
+..\FrameXML\UI.xsd">
+  <Script file="InterfaceOptionsPanels.lua"/>
+
+  <Frame name="SpellActivationOverlayOptionsPanel" hidden="true" parent="InterfaceOptionsFramePanelContainer">
+    <Layers>
+      <Layer level="ARTWORK">
+        <FontString name="$parentTitle" text="DISPLAY_LABEL" inherits="GameFontNormalLarge" justifyH="LEFT" justifyV="TOP">
+          <Anchors>
+            <Anchor point="TOPLEFT">
+              <Offset>
+                <AbsDimension x="16" y="-16"/>
+              </Offset>
+            </Anchor>
+          </Anchors>
+        </FontString>
+      </Layer>
+    </Layers>
+    <Frames>
+      <Slider name="$parentSpellAlertOpacitySlider" inherits="OptionsSliderTemplate">
+        <Anchors>
+          <Anchor point="TOPLEFT" relativeTo="$parentTitle" relativePoint="BOTTOMLEFT">
+            <Offset>
+              <AbsDimension x="24" y="-32"/>
+            </Offset>
+          </Anchor>
+        </Anchors>
+        <Scripts>
+          <!-- <OnLoad>
+            self:OnBackdropLoaded();
+            self.Text:SetText("Spell Alert opacity");
+          </OnLoad> -->
+          <!-- <OnLoad>
+            self.type = CONTROLTYPE_SLIDER;
+            self.cvar = "spellActivationOverlayOpacity";
+            self.SetDisplayValue = self.SetValue;
+            _G[self:GetName().."Low"]:SetText(OFF);
+            self.SetValue = function (self, value)
+print("Slider SetValue", self, value);
+              value = math.floor(value * 100 + 0.5) / 100;
+              self:SetDisplayValue(value);
+              if (value == 0) then
+                SpellActivationOverlayDB.alert.enabled = false;
+              else
+                SpellActivationOverlayDB.alert.enabled = true;
+              end
+              SpellActivationOverlayFrame:SetAlpha(value);
+            end
+            self.GetValue = function(self)
+print("Checkbox GetValue", self, SpellActivationOverlayDB.alert.opacity);
+              return SpellActivationOverlayDB.alert.opacity;
+            end
+            BlizzardOptionsPanel_RegisterControl(self, self:GetParent());
+            self:RegisterEvent("VARIABLES_LOADED");
+          </OnLoad>
+          <OnValueChanged>
+            value = math.floor(value * 100 + 0.5) / 100;
+            if (value ~= 0) then
+              value = math.max(0.5, value);
+            end
+            self.value = value;
+            self:SetValue(value);
+            SpellActivationOverlayDB.alert.opacity = value;
+          </OnValueChanged>
+          <OnEvent>
+            local value = tonumber(SpellActivationOverlayDB.alert.opacity);
+            value = math.floor(value * 100 + 0.5) / 100;
+            self:SetValue(value);
+          </OnEvent> -->
+        </Scripts>
+      </Slider>
+      <CheckButton name="$parentGlowingButtons" inherits="InterfaceOptionsCheckButtonTemplate">
+        <Anchors>
+          <Anchor point="TOPLEFT" relativeTo="$parentSpellAlertOpacitySlider" relativePoint="BOTTOMLEFT">
+            <Offset>
+              <AbsDimension x="0" y="-32"/>
+            </Offset>
+          </Anchor>
+        </Anchors>
+        <Scripts>
+          <!-- <OnLoad>
+            self.Text:SetText("Glowing Buttons");
+          </OnLoad> -->
+        </Scripts>
+      </CheckButton>
+    </Frames>
+    <Scripts>
+      <OnLoad function="SpellActivationOverlayOptionsPanel_OnLoad"/>
+    </Scripts>
+  </Frame>
+
+</Ui>

--- a/options/InterfaceOptionsPanels.xml
+++ b/options/InterfaceOptionsPanels.xml
@@ -54,6 +54,27 @@
           </Anchor>
         </Anchors>
       </Slider>
+      <Button name="$parentSpellAlertTestButton" inherits="OptionsButtonTemplate">
+        <Anchors>
+          <Anchor point="TOPLEFT" relativeTo="$parentSpellAlertOpacitySlider" relativePoint="TOPRIGHT">
+            <Offset>
+              <AbsDimension x="32" y="2"/>
+            </Offset>
+          </Anchor>
+        </Anchors>
+        <Scripts>
+          <OnClick>
+            if (not self.isTesting) then
+              self:StartTest();
+            else
+              self:StopTest();
+            end
+          </OnClick>
+          <OnHide>
+            self:StopTest();
+          </OnHide>
+        </Scripts>
+      </Button>
       <CheckButton name="$parentGlowingButtons" inherits="InterfaceOptionsCheckButtonTemplate">
         <Anchors>
           <Anchor point="TOPLEFT" relativeTo="$parentSpellAlertOffsetSlider" relativePoint="BOTTOMLEFT">

--- a/options/db.lua
+++ b/options/db.lua
@@ -7,14 +7,26 @@ function SAO.LoadDB(self)
 
     if not db.alert then
         db.alert = {};
+    end
+    if (type(db.alert.enabled) == "nil" and type(db.alert.opacity) == "nil") then
         db.alert.enabled = true;
         db.alert.opacity = 1;
+    elseif (type(db.alert.opacity) == "nil") then
+        db.alert.opacity = db.alert.enabled and 1 or 0;
+    elseif (type(db.alert.enabled) == "nil") then
+        db.alert.enabled = db.alert.opacity > 0;
+    end
+    if (type(db.alert.offset) == "nil") then
         db.alert.offset = 0;
+    end
+    if (type(db.alert.scale) == "nil") then
         db.alert.scale = 1;
     end
 
     if not db.glow then
         db.glow = {};
+    end
+    if (type(db.glow.enabled) == "nil") then
         db.glow.enabled = true;
     end
 

--- a/options/db.lua
+++ b/options/db.lua
@@ -1,4 +1,4 @@
-Addon, SAO =...
+local AddonName, SAO = ...
 
 -- Load database and use default values if needed
 function SAO.LoadDB(self)
@@ -20,10 +20,12 @@ function SAO.LoadDB(self)
     SpellActivationOverlayDB = db;
 end
 
-local frame = CreateFrame("Frame", "SpellActivationOverlayDBLoader");
-frame:RegisterEvent("VARIABLES_LOADED");
-frame:SetScript("OnEvent", function (event)
-    SAO.LoadDB();
-    SpellActivationOverlayOptionsPanel_Init();
-    frame:UnregisterEvent("VARIABLES_LOADED");
+-- Utility frame dedicated to react to variable loading
+local loader = CreateFrame("Frame", "SpellActivationOverlayDBLoader");
+loader:RegisterEvent("VARIABLES_LOADED");
+loader:SetScript("OnEvent", function (event)
+    SAO:LoadDB();
+    SAO:ApplyAllVariables();
+    SpellActivationOverlayOptionsPanel_Init(SAO.OptionsPanel);
+    loader:UnregisterEvent("VARIABLES_LOADED");
 end);

--- a/options/db.lua
+++ b/options/db.lua
@@ -9,6 +9,8 @@ function SAO.LoadDB(self)
         db.alert = {};
         db.alert.enabled = true;
         db.alert.opacity = 1;
+        db.alert.offset = 0;
+        db.alert.scale = 1;
     end
 
     if not db.glow then

--- a/options/db.lua
+++ b/options/db.lua
@@ -1,0 +1,29 @@
+Addon, SAO =...
+
+-- Load database and use default values if needed
+function SAO.LoadDB(self)
+    local currentversion = 060;
+    local db = SpellActivationOverlayDB or {};
+
+    if not db.alert then
+        db.alert = {};
+        db.alert.enabled = true;
+        db.alert.opacity = 0.65;
+    end
+
+    if not db.glow then
+        db.glow = {};
+        db.glow.enabled = true;
+    end
+
+    db.version = currentversion;
+    SpellActivationOverlayDB = db;
+end
+
+local frame = CreateFrame("Frame", "SpellActivationOverlayDBLoader");
+frame:RegisterEvent("VARIABLES_LOADED");
+frame:SetScript("OnEvent", function (event)
+    SAO.LoadDB();
+    SpellActivationOverlayOptionsPanel_Init();
+    frame:UnregisterEvent("VARIABLES_LOADED");
+end);

--- a/options/db.lua
+++ b/options/db.lua
@@ -8,7 +8,7 @@ function SAO.LoadDB(self)
     if not db.alert then
         db.alert = {};
         db.alert.enabled = true;
-        db.alert.opacity = 0.65;
+        db.alert.opacity = 1;
     end
 
     if not db.glow then

--- a/options/variables.lua
+++ b/options/variables.lua
@@ -1,0 +1,22 @@
+local AddonName, SAO = ...
+
+-- Apply all values from the database to the engine
+function SAO.ApplyAllVariables(self)
+    self:ApplySpellAlertOpacity();
+    self:ApplyGlowingButtonsToggle();
+end
+
+-- Apply spell alert opacity
+function SAO.ApplySpellAlertOpacity(self)
+    -- Change the main frame's opacity and adjust in-combat and out-of-combat animation transparency
+    SpellActivationOverlayContainerFrame:SetAlpha(SpellActivationOverlayDB.alert.opacity);
+end
+
+-- Apply glowing buttons on/off
+function SAO.ApplyGlowingButtonsToggle(self)
+    -- Don't do anything
+    -- Buttons will stop glowing by themselves, and will never light up again
+
+    -- A better function would be to stop glowing / start glowing now
+    -- But this would be more complex to code, and the benefit is minimal
+end

--- a/options/variables.lua
+++ b/options/variables.lua
@@ -9,7 +9,8 @@ end
 
 -- Apply spell alert opacity
 function SAO.ApplySpellAlertOpacity(self)
-    -- Change the main frame's opacity and adjust in-combat and out-of-combat animation transparency
+    -- Change the main frame's visibility and opacity
+    SpellActivationOverlayContainerFrame:SetShown(SpellActivationOverlayDB.alert.enabled);
     SpellActivationOverlayContainerFrame:SetAlpha(SpellActivationOverlayDB.alert.opacity);
 end
 

--- a/options/variables.lua
+++ b/options/variables.lua
@@ -3,6 +3,7 @@ local AddonName, SAO = ...
 -- Apply all values from the database to the engine
 function SAO.ApplyAllVariables(self)
     self:ApplySpellAlertOpacity();
+    self:ApplySpellAlertGeometry();
     self:ApplyGlowingButtonsToggle();
 end
 
@@ -10,6 +11,13 @@ end
 function SAO.ApplySpellAlertOpacity(self)
     -- Change the main frame's opacity and adjust in-combat and out-of-combat animation transparency
     SpellActivationOverlayContainerFrame:SetAlpha(SpellActivationOverlayDB.alert.opacity);
+end
+
+-- Apply spell alert geometry i.e., scale and offset
+function SAO.ApplySpellAlertGeometry(self)
+    SpellActivationOverlayFrame.scale = SpellActivationOverlayDB.alert.scale;
+    SpellActivationOverlayFrame.offset = SpellActivationOverlayDB.alert.offset;
+    SpellActivationOverlay_OnChangeGeometry(SpellActivationOverlayFrame);
 end
 
 -- Apply glowing buttons on/off


### PR DESCRIPTION
An options panel is displayed in Interface > AddOns > SpellActivationOverlay

Current options are:
- Spell Alert opacity
  - the value is either 0 (off) or between 50% and 100%
  - this is consistent with Retail's options for Spell Alerts
- Spell Alert scale factor
  - between 25% (4x smaller) and 250% (2.5x bigger)
- Spell Alert offset
  - between -200 pixels (almost no offset) and +400 pixels (wide gap)
- Glowing Buttons checkbox
  - simply an on/off switch

Spell Alerts can be tested interactively thanks to the "Toggle Test" button.

Please note: if Spell Alerts or Glowing Buttons are already displayed when changing these options, the Spell Alerts and Glowing Buttons may keep their old appearance until next time they are triggered.