### PR TITLE
Fix #11 Glowing Buttons

### DIFF
--- a/SpellActivationOverlay.lua
+++ b/SpellActivationOverlay.lua
@@ -147,7 +147,7 @@ function SpellActivationOverlay_ShowAllOverlays(self, spellID, texturePath, posi
 end
 
 function SpellActivationOverlay_ShowOverlay(self, spellID, texturePath, position, scale, r, g, b, vFlip, hFlip, cw, autoPulse, forcePulsePlay)
-	if (not SpellActivationOverlayDB.alert.enabled) then
+	if (SpellActivationOverlayDB and SpellActivationOverlayDB.alert and not SpellActivationOverlayDB.alert.enabled) then
 		return
 	end
 

--- a/SpellActivationOverlay.toc
+++ b/SpellActivationOverlay.toc
@@ -1,8 +1,8 @@
 ## Interface: 30400
-## Title: SpellActivationOverlay |cffa2f3ff0.6.0|r
+## Title: SpellActivationOverlay |cffa2f3ff0.6.1|r
 ## Notes: Mimic Spell Activation Overlays from Retail
 ## Author: Vinny
-## Version: 0.6.0
+## Version: 0.6.1
 ## SavedVariables: SpellActivationOverlayDB
 
 # SpellActivationOverlay.lua, SpellActivationOverlay.xml and all textures

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 #### v0.6.1 (2022-09-xx)
 
-- Buttons should glow correctly when using Dominos
+- Buttons should glow correctly when using Bartender, ElvUI or Dominos
 - Riposte should display its SAO as intended
 - Reload UI should no longer cause a Lua error because of options
 - Glowing Buttons checkbox should now apply the option correctly

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 #### v0.6.1 (2022-09-xx)
 
 - Buttons should glow correctly when using Dominos
+- Riposte should display its SAO as intended
 - Reload UI should no longer cause a Lua error because of options
 - Glowing Buttons checkbox should now apply the option correctly
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 ## SpellActivationOverlay Changelog
 
+#### v0.6.1 (2022-09-xx)
+
+- Buttons should glow correctly when using Dominos
+- Reload UI should no longer cause a Lua error because of options
+- Glowing Buttons checkbox should now apply the option correctly
+
 #### v0.6.0 (2022-09-04)
 
 - After extensive testing, SpellActivationOverlay now leaves its Beta phase!

--- a/components/counter.lua
+++ b/components/counter.lua
@@ -57,7 +57,7 @@ function SAO.CheckCounterAction(self, spellID, auraID)
     if (not self.ActivatedCounters[spellID] and counterMustBeActivated) then
         -- Counter triggered but not shown yet: just do it!
         self.ActivatedCounters[spellID] = true;
-        self:ActivateOverlay(select(2, aura));
+        self:ActivateOverlay(select(2, unpack(aura)));
         self:AddGlow(spellID, {spellID}); -- Same spell ID, because there is no 'aura'
     elseif (self.ActivatedCounters[spellID] and not counterMustBeActivated) then
         -- Counter not triggered but still shown: hide it

--- a/components/glow.lua
+++ b/components/glow.lua
@@ -50,9 +50,11 @@ end
 -- If forceRefresh is true, refresh even if old spell ID and new spell ID are identical
 -- Set forceRefresh if the spell ID of the button may switch from untracked to tracked (or vice versa) in light of recent events
 function SAO.UpdateActionButton(self, button, forceRefresh)
-    local oldAction = button.lastAction; -- Set by us, a few lines below
+--    local oldAction = button.lastAction; -- Set by us, a few lines below
+    local oldAction = button; -- Set by us, a few lines below
     local oldGlowID = button.lastGlowID; -- Set by us, a few lines below
-    local newAction = button.action; -- Set by the game, inside Blizzard's ActionButton.lua
+--    local newAction = button.action;
+    local newAction = button; -- In light of more research, it's better if newAction and oldAction are identical
     local newGlowID = nil;
     if HasAction(button.action) then
         newGlowID = self:GetSpellIDByActionSlot(button.action);

--- a/components/glow.lua
+++ b/components/glow.lua
@@ -114,7 +114,7 @@ function SAO.UpdateActionButton(self, button, forceRefresh)
     local mustGlow = newGlowID and (self.GlowingSpells[newGlowID] ~= nil);
 
     if (not wasGlowing and mustGlow) then
-        if (not SpellActivationOverlayDB.glow or SpellActivationOverlayDB.glow.enabled) then
+        if (not SpellActivationOverlayDB or not SpellActivationOverlayDB.glow or SpellActivationOverlayDB.glow.enabled) then
             ActionButton_ShowOverlayGlow(button);
         end
     elseif (wasGlowing and not mustGlow) then
@@ -162,7 +162,7 @@ function SAO.AddGlowNumber(self, spellID, glowID)
     else
         self.GlowingSpells[glowID] = { [spellID] = true };
         for _, frame in pairs(actionButtons or {}) do
-            if (not SpellActivationOverlayDB.glow or SpellActivationOverlayDB.glow.enabled) then
+            if (not SpellActivationOverlayDB or not SpellActivationOverlayDB.glow or SpellActivationOverlayDB.glow.enabled) then
                 ActionButton_ShowOverlayGlow(frame);
             end
         end

--- a/components/glow.lua
+++ b/components/glow.lua
@@ -51,10 +51,7 @@ end
 -- Set forceRefresh if the spell ID of the button may switch from untracked to tracked (or vice versa) in light of recent events
 function SAO.UpdateActionButton(self, button, forceRefresh)
     local oldGlowID = button.lastGlowID; -- Set by us, a few lines below
-    local newGlowID = nil;
-    if HasAction(button.action) then
-        newGlowID = self:GetSpellIDByActionSlot(button.action);
-    end
+    local newGlowID = button:GetGlowID();
     button.lastGlowID = newGlowID; -- Write button.lastGlowID here, but use oldGlowID/newGlowID for the rest of the function
 
     if (oldGlowID == newGlowID and not forceRefresh) then
@@ -126,6 +123,13 @@ function HookActionButton_Update(self)
         return;
     end
 
+    if (not self.GetGlowID) then
+        self.GetGlowID = function(self)
+            if (self.action and HasAction(self.action)) then
+                return SAO:GetSpellIDByActionSlot(self.action);
+            end
+        end
+    end
     SAO:UpdateActionButton(self);
 end
 hooksecurefunc("ActionButton_Update", HookActionButton_Update);

--- a/components/glow.lua
+++ b/components/glow.lua
@@ -50,16 +50,11 @@ end
 -- If forceRefresh is true, refresh even if old spell ID and new spell ID are identical
 -- Set forceRefresh if the spell ID of the button may switch from untracked to tracked (or vice versa) in light of recent events
 function SAO.UpdateActionButton(self, button, forceRefresh)
---    local oldAction = button.lastAction; -- Set by us, a few lines below
-    local oldAction = button; -- Set by us, a few lines below
     local oldGlowID = button.lastGlowID; -- Set by us, a few lines below
---    local newAction = button.action;
-    local newAction = button; -- In light of more research, it's better if newAction and oldAction are identical
     local newGlowID = nil;
     if HasAction(button.action) then
         newGlowID = self:GetSpellIDByActionSlot(button.action);
     end
-    button.lastAction = newAction; -- Write button.lastAction here, but use oldAction/newAction for the rest of the function
     button.lastGlowID = newGlowID; -- Write button.lastGlowID here, but use oldGlowID/newGlowID for the rest of the function
 
     if (oldGlowID == newGlowID and not forceRefresh) then
@@ -69,17 +64,17 @@ function SAO.UpdateActionButton(self, button, forceRefresh)
 
     -- Register/unregister button as 'dormant' i.e., not tracked but could be tracked in the future
     if (oldGlowID and not self.RegisteredGlowSpellIDs[oldGlowID] and type(self.DormantActionButtons[oldGlowID]) == 'table') then
-        if (self.DormantActionButtons[oldGlowID][oldAction] == button) then
-            self.DormantActionButtons[oldGlowID][oldAction] = nil;
+        if (self.DormantActionButtons[oldGlowID][button] == button) then
+            self.DormantActionButtons[oldGlowID][button] = nil;
         end
     end
     if (newGlowID and not self.RegisteredGlowSpellIDs[newGlowID]) then
         if (type(self.DormantActionButtons[newGlowID]) == 'table') then
-            if (self.DormantActionButtons[newGlowID][newAction] ~= button) then
-                self.DormantActionButtons[newGlowID][newAction] = button;
+            if (self.DormantActionButtons[newGlowID][button] ~= button) then
+                self.DormantActionButtons[newGlowID][button] = button;
             end
         else
-            self.DormantActionButtons[newGlowID] = { [newAction] = button };
+            self.DormantActionButtons[newGlowID] = { [button] = button };
         end
     end
 
@@ -91,23 +86,23 @@ function SAO.UpdateActionButton(self, button, forceRefresh)
     -- Untrack previous action button and track the new one
     if (oldGlowID and self.RegisteredGlowSpellIDs[oldGlowID] and type(self.ActionButtons[oldGlowID]) == 'table') then
         -- Detach action button from the former glow ID
-        if (self.ActionButtons[oldGlowID][oldAction] == button) then
-            self.ActionButtons[oldGlowID][oldAction] = nil;
+        if (self.ActionButtons[oldGlowID][button] == button) then
+            self.ActionButtons[oldGlowID][button] = nil;
         end
     end
     if (newGlowID and self.RegisteredGlowSpellIDs[newGlowID]) then
         if (type(self.ActionButtons[newGlowID]) == 'table') then
             -- Attach action button to the current glow ID
-            if (self.ActionButtons[newGlowID][newAction] ~= button) then
-                self.ActionButtons[newGlowID][newAction] = button;
+            if (self.ActionButtons[newGlowID][button] ~= button) then
+                self.ActionButtons[newGlowID][button] = button;
             end
         else
             -- This glow ID has no Action Buttons yet: be the first
-            self.ActionButtons[newGlowID] = { [newAction] = button };
+            self.ActionButtons[newGlowID] = { [button] = button };
         end
         -- Remove from the 'dormant' table, if it was dormant
-        if (type(self.DormantActionButtons[newGlowID]) == 'table' and self.DormantActionButtons[newGlowID][newAction] == button) then
-            self.DormantActionButtons[newGlowID][newAction] = nil;
+        if (type(self.DormantActionButtons[newGlowID]) == 'table' and self.DormantActionButtons[newGlowID][button] == button) then
+            self.DormantActionButtons[newGlowID][button] = nil;
         end
     end
 

--- a/components/glow.lua
+++ b/components/glow.lua
@@ -234,3 +234,42 @@ function SAO.RemoveGlow(self, spellID)
         end
     end
 end
+
+-- Track PLAYER_LOGIN which happens immediately after all ADDON_LOADED events
+-- Which means, at this point we know which addons are installed and loaded
+local binder = CreateFrame("Frame", "SpellActivationOverlayLABBinder");
+binder:RegisterEvent("PLAYER_LOGIN");
+binder:SetScript("OnEvent", function()
+    local LAB = LibStub("LibActionButton-1.0", true);
+    local LAB_ElvUI = LibStub("LibActionButton-1.0-ElvUI", true);
+    local LBG = LibStub("LibButtonGlow-1.0", true);
+
+    if ((LAB or LAB_ElvUI) and LBG) then
+
+        local buttonUpdateFunc = function(event, self)
+            if (not self.GetGlowID) then
+                self.GetGlowID = self.GetSpellId;
+            end
+            if (not self.EnableGlow) then
+                self.EnableGlow = function(button)
+                    LBG.ShowOverlayGlow(button);
+                end
+            end
+            if (not self.DisableGlow) then
+                self.DisableGlow = function(button)
+                    LBG.HideOverlayGlow(button);
+                end
+            end
+            SAO:UpdateActionButton(self);
+        end
+
+        if (LAB) then
+            LAB:RegisterCallback("OnButtonUpdate", buttonUpdateFunc);
+        end
+        if (LAB_ElvUI) then
+            LAB_ElvUI:RegisterCallback("OnButtonUpdate", buttonUpdateFunc);
+        end
+    end
+
+    binder:UnregisterEvent("PLAYER_LOGIN");
+end);

--- a/components/glow.lua
+++ b/components/glow.lua
@@ -3,7 +3,7 @@ local AddonName, SAO = ...
 -- List of known ActionButton instances that currently match one of the spell IDs to track
 -- This does not mean that buttons are glowing right now, but they could glow at any time
 -- key = glowID (= spellID of action), value = list of ActionButton objects for this spell
--- (side note: the sublist of buttons is a map of key = action slot and value = button)
+-- (side note: the sublist of buttons is a table of key = button and a dummy value = true)
 -- The list will change each time an action button changes, which may happen very often
 -- For example, any macro with [mod:shift] updates the list every time Shift is pressed
 SAO.ActionButtons = {}

--- a/components/glow.lua
+++ b/components/glow.lua
@@ -109,28 +109,38 @@ function SAO.UpdateActionButton(self, button, forceRefresh)
 
     if (not wasGlowing and mustGlow) then
         if (not SpellActivationOverlayDB or not SpellActivationOverlayDB.glow or SpellActivationOverlayDB.glow.enabled) then
-            ActionButton_ShowOverlayGlow(button);
+            button:EnableGlow();
         end
     elseif (wasGlowing and not mustGlow) then
-        ActionButton_HideOverlayGlow(button);
+        button:DisableGlow();
     end
 end
 
 -- Grab all action button activity that allows us to know which button has which spell
-function HookActionButton_Update(self)
-    if (self:GetParent() == OverrideActionBar) then
+function HookActionButton_Update(button)
+    if (button:GetParent() == OverrideActionBar) then
         -- Act on all buttons but the ones from OverrideActionBar, whatever that is
         return;
     end
 
-    if (not self.GetGlowID) then
-        self.GetGlowID = function(self)
-            if (self.action and HasAction(self.action)) then
-                return SAO:GetSpellIDByActionSlot(self.action);
+    if (not button.GetGlowID) then
+        button.GetGlowID = function(button)
+            if (button.action and HasAction(button.action)) then
+                return SAO:GetSpellIDByActionSlot(button.action);
             end
         end
     end
-    SAO:UpdateActionButton(self);
+    if (not button.EnableGlow) then
+        button.EnableGlow = function(button)
+            ActionButton_ShowOverlayGlow(button);
+        end
+    end
+    if (not button.DisableGlow) then
+        button.DisableGlow = function(button)
+            ActionButton_HideOverlayGlow(button);
+        end
+    end
+    SAO:UpdateActionButton(button);
 end
 hooksecurefunc("ActionButton_Update", HookActionButton_Update);
 
@@ -164,7 +174,7 @@ function SAO.AddGlowNumber(self, spellID, glowID)
         self.GlowingSpells[glowID] = { [spellID] = true };
         for _, frame in pairs(actionButtons or {}) do
             if (not SpellActivationOverlayDB or not SpellActivationOverlayDB.glow or SpellActivationOverlayDB.glow.enabled) then
-                ActionButton_ShowOverlayGlow(frame);
+                frame:EnableGlow();
             end
         end
     end
@@ -219,7 +229,7 @@ function SAO.RemoveGlow(self, spellID)
             self.GlowingSpells[glowSpellID] = nil;
             local actionButtons = self.ActionButtons[glowSpellID];
             for _, frame in pairs(actionButtons or {}) do
-                ActionButton_HideOverlayGlow(frame);
+                frame:DisableGlow();
             end
         end
     end

--- a/options/InterfaceOptionsPanels.lua
+++ b/options/InterfaceOptionsPanels.lua
@@ -71,25 +71,25 @@ function SpellActivationOverlayOptionsPanel_Init(self)
     glowingButtonCheckbox.Text:SetText("Glowing Buttons");
     glowingButtonCheckbox.initialValue = SpellActivationOverlayDB.glow.enabled;
     glowingButtonCheckbox:SetChecked(glowingButtonCheckbox.initialValue);
+    glowingButtonCheckbox.ApplyValueToEngine = function(self, checked)
+        SpellActivationOverlayDB.glow.enabled = checked;
+        SAO:ApplyGlowingButtonsToggle();
+    end
 end
 
 -- User clicks OK to the options panel
 local function okayFunc(self)
     local opacitySlider = SpellActivationOverlayOptionsPanelSpellAlertOpacitySlider;
     opacitySlider.initialValue = opacitySlider:GetValue();
-    -- SAO:ApplySpellAlertOpacity(); -- Not necessary because this option is interactive
 
     local scaleSlider = SpellActivationOverlayOptionsPanelSpellAlertScaleSlider;
     scaleSlider.initialValue = scaleSlider:GetValue();
-    -- SAO:ApplySpellAlertGeometry(); -- Not necessary because this option is interactive
 
     local offsetSlider = SpellActivationOverlayOptionsPanelSpellAlertOffsetSlider;
     offsetSlider.initialValue = offsetSlider:GetValue();
-    -- SAO:ApplySpellAlertGeometry(); -- Not necessary because this option is interactive
 
     local glowingButtonCheckbox = SpellActivationOverlayOptionsPanelGlowingButtons;
     glowingButtonCheckbox.initialValue = glowingButtonCheckbox:GetChecked();
-    SAO:ApplyGlowingButtonsToggle();
 end
 
 -- User clicked Cancel to the options panel

--- a/options/InterfaceOptionsPanels.xml
+++ b/options/InterfaceOptionsPanels.xml
@@ -102,6 +102,13 @@
             </Offset>
           </Anchor>
         </Anchors>
+        <Scripts>
+          <PostClick>
+            if (self.ApplyValueToEngine) then
+              self:ApplyValueToEngine(self:GetChecked());
+            end
+          </PostClick>
+        </Scripts>
       </CheckButton>
     </Frames>
     <Scripts>


### PR DESCRIPTION
Squashed many bugs with Glowing Action Buttons.

The most visible fix is that buttons should now glow with UI managers, such as Bartender, ElvUI or Dominos.
- Dominos are compatible with Blizzard action buttons, thus they use "Blizzard Glow"
- Bartender uses the "Blizzard Glow" by default
- ElvUI uses the "Pixel Glow" by default