### PR TITLE
Makes button glow during GCD. Doesn't glow if spell is on CD

### DIFF
--- a/components/counter.lua
+++ b/components/counter.lua
@@ -52,7 +52,11 @@ function SAO.CheckCounterAction(self, spellID, auraID)
     end
 
     local isCounterUsable = IsUsableSpell(spellID);
-    local counterMustBeActivated = isCounterUsable and start == 0;
+    local _, gcdDuration, _, _ = GetSpellCooldown(61304); -- GCD SpellID
+    -- We check against gcdDuration because it's not always 1.5s
+    local isGCD = duration <= gcdDuration;
+    local isCounterOnCD = start > 0 and not isGCD; 
+    local counterMustBeActivated = isCounterUsable and not isCounterOnCD;
 
     if (not self.ActivatedCounters[spellID] and counterMustBeActivated) then
         -- Counter triggered but not shown yet: just do it!


### PR DESCRIPTION
Checks if the player is under the GCD. Counter spells that are usable keep glowing in that case. It stops glowing if the spell enters on CD.

I've tested this with Riposte. It stops glowing after the spell is used.
Execute keeps glowing after being used and regardless of whether the GCD is active.

This should fix #54.
