### PR TITLE
Non-mana counter spells glow when they aren't usable because of low resources

### DIFF
--- a/components/counter.lua
+++ b/components/counter.lua
@@ -51,12 +51,12 @@ function SAO.CheckCounterAction(self, spellID, auraID)
         return;
     end
 
-    local isCounterUsable = IsUsableSpell(spellID);
+    local isCounterUsable, noMana = IsUsableSpell(spellID);
     local _, gcdDuration, _, _ = GetSpellCooldown(61304); -- GCD SpellID
     -- We check against gcdDuration because it's not always 1.5s
     local isGCD = duration <= gcdDuration;
     local isCounterOnCD = start > 0 and not isGCD; 
-    local counterMustBeActivated = isCounterUsable and not isCounterOnCD;
+    local counterMustBeActivated = (isCounterUsable or noMana) and not isCounterOnCD;
 
     if (not self.ActivatedCounters[spellID] and counterMustBeActivated) then
         -- Counter triggered but not shown yet: just do it!

--- a/components/counter.lua
+++ b/components/counter.lua
@@ -51,12 +51,22 @@ function SAO.CheckCounterAction(self, spellID, auraID)
         return;
     end
 
-    local isCounterUsable, noMana = IsUsableSpell(spellID);
+    local isCounterUsable, notEnoughPower = IsUsableSpell(spellID);
+    
     local _, gcdDuration, _, _ = GetSpellCooldown(61304); -- GCD SpellID
-    -- We check against gcdDuration because it's not always 1.5s
-    local isGCD = duration <= gcdDuration;
+    local isGCD = duration <= gcdDuration; -- We check against gcdDuration because it's not always 1.5s
     local isCounterOnCD = start > 0 and not isGCD; 
-    local counterMustBeActivated = (isCounterUsable or noMana) and not isCounterOnCD;
+
+    -- Non-mana spells should always glow, regardless of player's current resources.
+    local costsMana = false
+    for _, spellCost in ipairs(GetSpellPowerCost(spellID)) do
+        if spellCost.name == "MANA" then
+            costsMana = true;
+            break;
+        end
+    end
+
+    local counterMustBeActivated = not isCounterOnCD and (isCounterUsable or (notEnoughPower and not costsMana));
 
     if (not self.ActivatedCounters[spellID] and counterMustBeActivated) then
         -- Counter triggered but not shown yet: just do it!


### PR DESCRIPTION
On the current version, counter spells (e.g. Execute or Overpower) stop and restart glowing depending on whether the player has enough resources to cast them. This behavior is inconsistent with spell overlay effects (e.g. Exorcism or Flash Light because of Art of War), which keep glowing regardless of player resources.

With this PR, counter spells mimic the behavior of spells with overlay, glowing regardless of current mana, rage or energy.

This can be done tanks to another return parameter of [IsUsableSpell](https://wowpedia.fandom.com/wiki/API_IsUsableSpell)