### PR TITLE
GetSpellPowerCost may return "no value"

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 ## SpellActivationOverlay Changelog
 
+#### v0.6.4 (2022-09-xx)
+
+- Lua errors of 'ipairs' should no longer occur after a loading screen
+
 #### v0.6.3 (2022-09-20)
 
 - New SAO: Warlock's Decimation

--- a/components/counter.lua
+++ b/components/counter.lua
@@ -70,7 +70,7 @@ function SAO.CheckCounterAction(self, spellID, auraID, talent)
 
     -- Non-mana spells should always glow, regardless of player's current resources.
     local costsMana = false
-    for _, spellCost in ipairs(GetSpellPowerCost(spellID)) do
+    for _, spellCost in ipairs(GetSpellPowerCost(spellID) or {}) do
         if spellCost.name == "MANA" then
             costsMana = true;
             break;


### PR DESCRIPTION
In theory, GetSpellPowerCost should always return something if the spell is learned. But for some reason, the function sometimes returns "no value" during the loading screen.

Because of this, the player may see a Lua error at the end of a loading screen e.g., when leaving a battleground.

This Pull Request handles this case by simply offering an empty table to `ipairs` when the function returns "no value".