### PR TITLE
Remove SAO/GAB if effect is absent after loading

### DIFF
--- a/SpellActivationOverlay.lua
+++ b/SpellActivationOverlay.lua
@@ -42,6 +42,7 @@ function SpellActivationOverlay_OnLoad(self)
 	self:RegisterEvent("PLAYER_REGEN_DISABLED");
 	self:RegisterEvent("SPELLS_CHANGED");
 	self:RegisterEvent("LEARNED_SPELL_IN_TAB");
+	self:RegisterEvent("LOADING_SCREEN_DISABLED");
 end
 
 function SpellActivationOverlay_OnChangeGeometry(self)

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 #### v0.6.4 (2022-09-xx)
 
+- SAOs and GABs should disappear if their triggers fade during a loading screen
 - Lua errors of 'ipairs' should no longer occur after a loading screen
 
 #### v0.6.3 (2022-09-20)

--- a/components/events.lua
+++ b/components/events.lua
@@ -77,6 +77,17 @@ function SAO.COMBAT_LOG_EVENT_UNFILTERED(self, ...)
     end
 end
 
+-- Check if auras are still there after a loading screen
+-- This circumvents a limitation of the CLEU which may not trigger during a loading screen
+function SAO.LOADING_SCREEN_DISABLED(self, ...)
+    for spellID, stacks in pairs(self.ActiveOverlays) do
+        if (not self:FindPlayerAuraByID(spellID)) then
+            self:DeactivateOverlay(spellID);
+            self:RemoveGlow(spellID);
+        end
+    end
+end
+
 function SAO.SPELL_UPDATE_USABLE(self, ...)
     self:CheckAllCounterActions();
 end


### PR DESCRIPTION
Register to the LOADING_SCREEN_DISABLED event and remove all SAOs and GABs attached to a buff if the buff is not present after loading.

This solution is very simple and efficient, but at a cost: it assumes the spellID refers to an actual aura, which is not always true.

In practice, this should not be a big problem because:
- most "auras" have an actual aura which matches their respective spellID
- loading screens occurs after e.g., transportation, hearthstone, etc., where procs are rarely needed immediately
- this affects only a handful of "fake auras", namely Heating Up and many druid effects
- this also affects aura testing in options panel ("Toggle Test" button) but it should be marginally problematic