### PR TITLE
Out-of-combat has 3 steps, down to alpha=0%

### DIFF
--- a/SpellActivationOverlay.lua
+++ b/SpellActivationOverlay.lua
@@ -310,5 +310,5 @@ end
 
 function SpellActivationOverlayFrame_OnFadeOutFinished(anim)
 	local frame = anim:GetParent();
-	frame:SetAlpha(0.5);
+	frame:SetAlpha(0);
 end

--- a/SpellActivationOverlay.toc
+++ b/SpellActivationOverlay.toc
@@ -1,8 +1,8 @@
 ## Interface: 30400
-## Title: SpellActivationOverlay |cffa2f3ff0.6.3|r
+## Title: SpellActivationOverlay |cffa2f3ff0.6.4|r
 ## Notes: Mimic Spell Activation Overlays from Retail
 ## Author: Vinny
-## Version: 0.6.3
+## Version: 0.6.4
 ## SavedVariables: SpellActivationOverlayDB
 
 # SpellActivationOverlay.lua, SpellActivationOverlay.xml and all textures

--- a/SpellActivationOverlay.xml
+++ b/SpellActivationOverlay.xml
@@ -50,7 +50,9 @@
 						</Scripts>
 					</AnimationGroup>
 					<AnimationGroup name="$leavingCombatAnim" parentKey="combatAnimOut">
-						<Alpha fromAlpha="1" toAlpha="0.5" duration="0.2"/>
+						<Alpha     order="1" duration="0.2" fromAlpha="1" toAlpha="0.5"/>
+						<Animation order="2" duration="27.8"/>
+						<Alpha     order="3" duration="2" fromAlpha="0.5" toAlpha="0"/>
 						<Scripts>
 							<OnFinished function="SpellActivationOverlayFrame_OnFadeOutFinished"/>
 						</Scripts>

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 #### v0.6.4 (2022-09-xx)
 
+- Spell Alerts fade out after being out of combat for 30 seconds
 - SAOs and GABs should disappear if their triggers fade during a loading screen
 - Lua errors of 'ipairs' should no longer occur after a loading screen
 


### PR DESCRIPTION
The 3 steps are:
1. from alpha=100% to alpha=50% in 0.2 seconds (current behavior)
2. then don't do anything for 27.8 seconds
3. then, from alpha=50% to alpha=0% in 2 seconds (new)

This means the effect quickly dims when out of combat, then doesn't change for a while, and then slowly fades out. All steps combined will happen in a total of 30 seconds (0.2+27.8+2 = 30).

Because all steps are performed by the XML schema, this feature should have zero impact on the animation stability or performance.

Because effects normally don't last for more than 30 seconds, this fade-out should be seen only by Fire mages with the Heating Up effect, which has an infinite duration.