### PR TITLE
GetGlowID in vehicle

### DIFF
--- a/SpellActivationOverlay.toc
+++ b/SpellActivationOverlay.toc
@@ -1,8 +1,8 @@
 ## Interface: 30400
-## Title: SpellActivationOverlay |cffa2f3ff0.6.4|r
+## Title: SpellActivationOverlay |cffa2f3ff0.6.5|r
 ## Notes: Mimic Spell Activation Overlays from Retail
 ## Author: Vinny
-## Version: 0.6.4
+## Version: 0.6.5
 ## SavedVariables: SpellActivationOverlayDB
 
 # SpellActivationOverlay.lua, SpellActivationOverlay.xml and all textures

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 ## SpellActivationOverlay Changelog
 
+#### v0.6.5 (2022-10-xx)
+
+- Entering a vehicle should no longer cause a Lua error
+
 #### v0.6.4 (2022-09-29)
 
 - Spell Alerts fade out after being out of combat for 30 seconds

--- a/components/glow.lua
+++ b/components/glow.lua
@@ -251,6 +251,12 @@ binder:SetScript("OnEvent", function()
     local LCG = LibStub("LibCustomGlow-1.0", true);
 
     local buttonUpdateFunc = function(libGlow, event, self)
+        if (self._state_type ~= "action") then
+            -- If button is not an "action", then GetSpellId is unusable
+            -- This happens for instance with vehicle buttons
+            -- They are probably not meant to glow, so it's simpler to just ignore them
+            return;
+        end
         if (not self.GetGlowID) then
             self.GetGlowID = self.GetSpellId;
         end


### PR DESCRIPTION
The Lua error occurred in GetGlowID which, in fact, was internally LibActionButton's GetSpellId which then called GetActionInfo with the wrong arguments.

It's unsure whether the error is a misuse of LibActionButton or if LibActionButton should be safer, but we can prevent this on our side, so let's do it.

Fixes #82.