### PR TITLE
SAO/GAB for Art of War with 1 talent point

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 #### v0.6.5 (2022-10-xx)
 
 - Entering a vehicle should no longer cause a Lua error
+- Spending 1 point out of 2 in Art of War now has a SAO and GABs
 
 #### v0.6.4 (2022-09-29)
 

--- a/classes/paladin.lua
+++ b/classes/paladin.lua
@@ -12,6 +12,7 @@ local function registerClass(self)
 
     -- Art of War
     self:RegisterAura("art_of_war", 0, 59578, "art_of_war", "Left + Right (Flipped)", 1, 255, 255, 255, true, { flashOfLight, exorcism });
+    self:RegisterAura("art_of_war_mini", 0, 53489, "art_of_war", "Left + Right (Flipped)", 0.6, 255, 255, 255, false, { flashOfLight, exorcism }); -- 1 point out of 2, displayed smaller, does not pulse
 
     -- Infusion of Light, 1/2 talent points
     self:RegisterAura("infusion_of_light_low", 0, 53672, "daybreak", "Left + Right (Flipped)", 1, 255, 255, 255, true, { flashOfLight, holyLight });


### PR DESCRIPTION
Uses the same texture as Art of War with 2 talent points, but smaller SAO does not pulse.
GABs are the same as Art of War with 2 talent points.
Fixes #81.