### PR TITLE
ElvUI 13 regression

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -165,7 +165,8 @@
         "UIDropDownMenu_GetText",
         "UIDropDownMenu_EnableDropDown",
         "UIDropDownMenu_DisableDropDown",
-        "CloseDropDownMenus"
+        "CloseDropDownMenus",
+        "ElvUI"
     ],
     "workbench.colorCustomizations": {
         "activityBar.activeBackground": "#4f71dc",

--- a/SpellActivationOverlay.toc
+++ b/SpellActivationOverlay.toc
@@ -1,8 +1,8 @@
 ## Interface: 30400
-## Title: SpellActivationOverlay |cffa2f3ff0.8.0|r
+## Title: SpellActivationOverlay |cffa2f3ff0.8.1|r
 ## Notes: Mimic Spell Activation Overlays from Retail
 ## Author: Vinny
-## Version: 0.8.0
+## Version: 0.8.1
 ## SavedVariables: SpellActivationOverlayDB
 
 # SpellActivationOverlay.lua, SpellActivationOverlay.xml and all textures

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 ## SpellActivationOverlay Changelog
 
+#### v0.8.1 (2022-11-13)
+
+- The default glowing button library is now LibButtonGlow for ElvUI 13
+
 #### v0.8.0 (2022-11-08)
 
 - SAOs and GABs can be previewed by moving the cursor over their options

--- a/components/glow.lua
+++ b/components/glow.lua
@@ -311,10 +311,24 @@ binder:SetScript("OnEvent", function()
     end
 
     -- Support for ElvUI's LibActionButton
-    if (LAB_ElvUI and LCG) then -- Prioritize LibCustomGlow, if available
-        LAB_ElvUI:RegisterCallback("OnButtonUpdate", LCGButtonUpdateFunc);
-    elseif (LAB_ElvUI and LBG) then -- Otherwise fall back to LibButtonGlow
-        LAB_ElvUI:RegisterCallback("OnButtonUpdate", LBGButtonUpdateFunc);
+    if (LAB_ElvUI) then
+        -- For some time, ElvUI favored LibCustomGlow by default
+        -- On ElvUI 13.01 and higher, LibButtonGlow is the official lib for ElvUI
+        -- This is probably due to a bug of LibCustomGlow under ElvUI 13
+        -- Although we're not sure if the bug existed in 13.00, we favor LBG for all 13.xx versions
+        if (ElvUI and ElvUI[1] and type(ElvUI[1].version) == 'number' and ElvUI[1].version >= 13) then
+            if (LBG) then
+                LAB_ElvUI:RegisterCallback("OnButtonUpdate", LBGButtonUpdateFunc);
+            elseif (LCG) then
+                LAB_ElvUI:RegisterCallback("OnButtonUpdate", LCGButtonUpdateFunc);
+            end
+        else
+            if (LCG) then -- Prioritize LibCustomGlow, if available
+                LAB_ElvUI:RegisterCallback("OnButtonUpdate", LCGButtonUpdateFunc);
+            elseif (LBG) then -- Otherwise fall back to LibButtonGlow
+                LAB_ElvUI:RegisterCallback("OnButtonUpdate", LBGButtonUpdateFunc);
+            end
+        end
     end
 
     binder:UnregisterEvent("PLAYER_LOGIN");


### PR DESCRIPTION
Due to recent changes of ElvUI, side effects made almost impossible to get glowing buttons for ElvUI users, and sometimes spell alerts too.

Fixes #105.