### PR TITLE
Azilroka Ulduar

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -166,7 +166,9 @@
         "UIDropDownMenu_EnableDropDown",
         "UIDropDownMenu_DisableDropDown",
         "CloseDropDownMenus",
-        "ElvUI"
+        "ElvUI",
+        "ProjectAzilroka",
+        "strfind"
     ],
     "workbench.colorCustomizations": {
         "activityBar.activeBackground": "#4f71dc",

--- a/SpellActivationOverlay.toc
+++ b/SpellActivationOverlay.toc
@@ -1,8 +1,8 @@
 ## Interface: 30401
-## Title: SpellActivationOverlay |cffa2f3ff0.8.2|r
+## Title: SpellActivationOverlay |cffa2f3ff0.8.3|r
 ## Notes: Mimic Spell Activation Overlays from Retail
 ## Author: Vinny
-## Version: 0.8.2
+## Version: 0.8.3
 ## SavedVariables: SpellActivationOverlayDB
 
 # SpellActivationOverlay.lua, SpellActivationOverlay.xml and all textures

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 ## SpellActivationOverlay Changelog
 
+#### v0.8.3 (2022-01-29)
+
+- Glowing buttons work again with ProjectAzilroka, after Ulduar patch
+- Mage's Heating Up works again with ProjectAzilroka, after Ulduar patch
+- Other features may also work back to normal for ProjectAzilroka users
+
 #### v0.8.2 (2022-01-18)
 
 - Bump in TOC file for Ulduar patch

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,8 @@
 - Glowing buttons work again with ProjectAzilroka, after Ulduar patch
 - Mage's Heating Up works again with ProjectAzilroka, after Ulduar patch
 - Other features may also work back to normal for ProjectAzilroka users
+- These fixes also apply to addons embedding an outdated LibButtonGlow
+- If there is no fallback solution, glowing buttons are temporarily disabled
 
 #### v0.8.2 (2022-01-18)
 

--- a/components/glow.lua
+++ b/components/glow.lua
@@ -257,6 +257,22 @@ function SAO.RemoveGlow(self, spellID)
     end
 end
 
+local warnedOutdatedLBG = false
+local function warnOutdatedLBG()
+    -- Warn players that their configuration has an issue with glowing buttons
+    -- There is one case where this warning is misleading: if LibActionButton for ElvUI and for non-ElvUI are loaded at the same time
+    -- But this should not happen in practice, because ElvUI usually replaces pretty much anything UI-related in the game
+    if warnedOutdatedLBG then return end
+
+    local text = "[|cffa2f3ff"..AddonName.."|r] One of your addons uses an old version of LibButtonGlow. "
+               .."|cffff0000Please consider updating your addons|r. "
+               .."Glowing buttons have been |cffff8040temporarily disabled|r to prevent issues. "
+               .."(note: the Glowing Buttons option can still be enabled, but it will have no effect until the faulty addon is up-to-date)";
+    print(text);
+
+    warnedOutdatedLBG = true
+end
+
 -- Track PLAYER_LOGIN which happens immediately after all ADDON_LOADED events
 -- Which means, at this point we know which addons are installed and loaded
 local binder = CreateFrame("Frame", "SpellActivationOverlayLABBinder");
@@ -269,7 +285,7 @@ binder:SetScript("OnEvent", function()
 
     local LAB = LibStub("LibActionButton-1.0", true);
     local LAB_ElvUI = LibStub("LibActionButton-1.0-ElvUI", true);
-    local LBG = LibStub("LibButtonGlow-1.0", true);
+    local LBG, LBGversion = LibStub("LibButtonGlow-1.0", true);
     local LCG = LibStub("LibCustomGlow-1.0", true);
 
     local buttonUpdateFunc = function(libGlow, event, self)
@@ -303,11 +319,13 @@ binder:SetScript("OnEvent", function()
         buttonUpdateFunc(LCG, event, self);
     end
 
-    -- Support for LibActionButton e.g., used by Bartender
-    if (LAB and LBG) then -- Prioritize LibButtonGlow, if available
+    -- Support for LibActionButton used by e.g., Bartender
+    if (LAB and LBG and LBGversion >= 8) then -- Prioritize LibButtonGlow, if available
         LAB:RegisterCallback("OnButtonUpdate", LBGButtonUpdateFunc);
     elseif (LAB and LCG) then -- Otherwise fall back to LibCustomGlow
         LAB:RegisterCallback("OnButtonUpdate", LCGButtonUpdateFunc);
+    elseif (LAB and LBG) then
+        warnOutdatedLBG();
     end
 
     -- Support for ElvUI's LibActionButton
@@ -332,16 +350,20 @@ binder:SetScript("OnEvent", function()
             end
         end 
         if (hasElvUI13OrHigher and not hasAzilroka186OrLower) then
-            if (LBG) then
+            if (LBG and LBGversion >= 8) then
                 LAB_ElvUI:RegisterCallback("OnButtonUpdate", LBGButtonUpdateFunc);
             elseif (LCG) then
                 LAB_ElvUI:RegisterCallback("OnButtonUpdate", LCGButtonUpdateFunc);
+            elseif (LBG) then
+                warnOutdatedLBG();
             end
         else
             if (LCG) then -- Prioritize LibCustomGlow, if available
                 LAB_ElvUI:RegisterCallback("OnButtonUpdate", LCGButtonUpdateFunc);
-            elseif (LBG) then -- Otherwise fall back to LibButtonGlow
+            elseif (LBG and LBGversion >= 8) then -- Otherwise fall back to LibButtonGlow
                 LAB_ElvUI:RegisterCallback("OnButtonUpdate", LBGButtonUpdateFunc);
+            elseif (LBG) then
+                warnOutdatedLBG();
             end
         end
     end

--- a/components/glow.lua
+++ b/components/glow.lua
@@ -316,7 +316,22 @@ binder:SetScript("OnEvent", function()
         -- On ElvUI 13.01 and higher, LibButtonGlow is the official lib for ElvUI
         -- This is probably due to a bug of LibCustomGlow under ElvUI 13
         -- Although we're not sure if the bug existed in 13.00, we favor LBG for all 13.xx versions
-        if (ElvUI and ElvUI[1] and type(ElvUI[1].version) == 'number' and ElvUI[1].version >= 13) then
+        local hasElvUI13OrHigher = false
+        if (ElvUI and ElvUI[1] and type(ElvUI[1].version) == 'number') then
+            hasElvUI13OrHigher = ElvUI[1].version >= 13
+        end
+        -- However, there is a bug with ProjectAzilroka which hasn't been updated since Ulduar patch
+        -- So we switch back to the old priority if an old Azilroka is found
+        local hasAzilroka186OrLower = false
+        if (ProjectAzilroka and type(ProjectAzilroka.Version) == 'string') then
+            local _, _, azilMajor, azilMinor = strfind(ProjectAzilroka.Version, "(%d+)%.(%d+)")
+            azilMajor = tonumber(azilMajor)
+            azilMinor = tonumber(azilMinor)
+            if (type(azilMajor) == 'number' and type(azilMinor) == 'number') then
+                hasAzilroka186OrLower = azilMajor < 1 or azilMajor == 1 and azilMinor <= 86
+            end
+        end 
+        if (hasElvUI13OrHigher and not hasAzilroka186OrLower) then
             if (LBG) then
                 LAB_ElvUI:RegisterCallback("OnButtonUpdate", LBGButtonUpdateFunc);
             elseif (LCG) then

--- a/options/db.lua
+++ b/options/db.lua
@@ -2,7 +2,7 @@ local AddonName, SAO = ...
 
 -- Load database and use default values if needed
 function SAO.LoadDB(self)
-    local currentversion = 080;
+    local currentversion = 083;
     local db = SpellActivationOverlayDB or {};
 
     if not db.alert then


### PR DESCRIPTION
Detects addons with too old version of LibButtonGlow, and prevent usage of glowing buttons to prevent issues.