### PR TITLE
Optimize frequents calls as 'local'

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 ## SpellActivationOverlay Changelog
 
+#### v0.8.5 (2022-05-xx)
+
+- The addon should now use a bit less CPU than before
+
 #### v0.8.4 (2022-04-28)
 
 - New SAO: Druid's Wrath of Elune (4p set bonus of PvP season 5-6-7-8)

--- a/classes/druid.lua
+++ b/classes/druid.lua
@@ -1,5 +1,11 @@
 local AddonName, SAO = ...
 
+-- Optimize frequent calls
+local CombatLogGetCurrentEventInfo = CombatLogGetCurrentEventInfo
+local GetShapeshiftForm = GetShapeshiftForm
+local GetSpellInfo = GetSpellInfo
+local UnitGUID = UnitGUID
+
 local omenSpellID = 16870;
 local lunarSpellID = 48518;
 local solarSpellID = 48517;

--- a/classes/mage.lua
+++ b/classes/mage.lua
@@ -1,5 +1,9 @@
 local AddonName, SAO = ...
 
+-- Optimize frequent calls
+local CombatLogGetCurrentEventInfo = CombatLogGetCurrentEventInfo
+local GetTalentInfo = GetTalentInfo
+
 local clearcastingVariants; -- Lazy init in lazyCreateClearcastingVariants()
 
 local hotStreakSpellID = 48108;

--- a/components/counter.lua
+++ b/components/counter.lua
@@ -1,5 +1,11 @@
 local AddonName, SAO = ...
 
+-- Optimize frequent calls
+local GetSpellCooldown = GetSpellCooldown
+local GetSpellPowerCost = GetSpellPowerCost
+local GetTalentInfo = GetTalentInfo
+local IsUsableSpell = IsUsableSpell
+
 -- List of spell names or IDs of actions that can trigger as 'counter'
 -- key = spellName / spellID, value = { auraID, talent }
 SAO.ActivableCountersByName = {};

--- a/components/events.lua
+++ b/components/events.lua
@@ -1,5 +1,8 @@
 local AddonName, SAO = ...
 
+-- Optimize frequent calls
+local CombatLogGetCurrentEventInfo = CombatLogGetCurrentEventInfo
+
 -- Events starting with SPELL_AURA e.g., SPELL_AURA_APPLIED
 -- This should be invoked only if the buff is done on the player i.e., UnitGUID("player") == destGUID
 function SAO.SPELL_AURA(self, ...)

--- a/components/glow.lua
+++ b/components/glow.lua
@@ -1,5 +1,8 @@
 local AddonName, SAO = ...
 
+-- Optimize frequent calls
+local HasAction = HasAction
+
 -- List of known ActionButton instances that currently match one of the spell IDs to track
 -- This does not mean that buttons are glowing right now, but they could glow at any time
 -- key = glowID (= spellID of action), value = list of ActionButton objects for this spell

--- a/components/spell.lua
+++ b/components/spell.lua
@@ -1,5 +1,8 @@
 local AddonName, SAO = ...
 
+-- Optimize frequent calls
+local GetSpellInfo = GetSpellInfo
+
 -- List of spell IDs sharing the same name
 -- key = spell name, value = list of spell IDs
 -- The list is a cache of calls to GetSpellIDsByName

--- a/components/util.lua
+++ b/components/util.lua
@@ -2,6 +2,16 @@ local AddonName, SAO = ...
 
 -- This script file is not a 'component' per se, but its functions are used across components
 
+-- Optimize frequent calls
+local GetActionInfo = GetActionInfo
+local GetNumTalents = GetNumTalents
+local GetNumTalentTabs = GetNumTalentTabs
+local GetSpellBookItemName = GetSpellBookItemName
+local GetSpellInfo = GetSpellInfo
+local GetSpellTabInfo = GetSpellTabInfo
+local GetTalentInfo = GetTalentInfo
+local UnitBuff = UnitBuff
+
 -- Utility aura function, one of the many that Blizzard could've done better years ago...
 function SAO.FindPlayerAuraByID(self, id)
     local i = 1


### PR DESCRIPTION
The `local` keyword allows to transform _farcall_ functions to non-far calls.

It allegedly optimize calls that happen frequently.