### PR TITLE
Heating Up after respec

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -171,7 +171,8 @@
         "strfind",
         "STATUS_TEXT_BOTH",
         "ACTION_SPELL_AURA_APPLIED_DOSE",
-        "GetFileIDFromPath"
+        "GetFileIDFromPath",
+        "WOW_PROJECT_WRATH_CLASSIC"
     ],
     "workbench.colorCustomizations": {
         "activityBar.activeBackground": "#4f71dc",

--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,8 @@
 #### v0.9.0 (2022-05-xx)
 
 - Support for Classic Era, although many WotLK spells and talents are missing
-- Fixed an issue where paladin and warrior buttons would not glow
+- Mage's Heating Up effect is now hidden when the talent is lost e.g., respec
+- Fixed an issue where paladin and warrior buttons would sometimes not glow
 - The addon should now use a bit less CPU than before
 
 #### v0.8.4 (2022-04-28)


### PR DESCRIPTION
Fixes #111.

The Heating Up effect is now hidden and restored when switching back and forth a Fire spec
- when losing the Hot Streak talent while Heating Up is active, the Heating Up effect is banked and hidden for the time being
- when gaining the Hot Streak talent after having banked Heating Up, the Heating Up effect is restored