### PR TITLE
Drain Soul execute

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -177,7 +177,8 @@
         "DEFAULT",
         "UnitCanAttack",
         "UnitHealth",
-        "UnitHealthMax"
+        "UnitHealthMax",
+        "HEALTH_COST_PCT"
     ],
     "workbench.colorCustomizations": {
         "activityBar.activeBackground": "#4f71dc",

--- a/_curse/release_notes.html
+++ b/_curse/release_notes.html
@@ -82,7 +82,7 @@
 <img src="https://i.imgur.com/fZbPl4T.gif" alt="Tidal Waves" width="256" height="256" />
 </p>
 <p>&nbsp;</p>
-<h4><strong>Warlock</strong>: Backlash, Empowered Imp, Nightfall, Molten Core, Decimation</h4>
+<h4><strong>Warlock</strong>: Backlash, Empowered Imp, Nightfall, Molten Core, Decimation, Drain Soul (glowing button only, optional)</h4>
 <p>
 <img src="https://i.imgur.com/6RkAm4C.gif" alt="Backlash" width="256" height="256" />
 &nbsp;

--- a/changelog.md
+++ b/changelog.md
@@ -2,9 +2,13 @@
 
 #### v0.9.1 (2022-05-xx)
 
-- Option to see Warrior's Overpower in any stance
-- Option to see Warrior's Revenge in any stance
-- Option to see Warrior's Execute in any stance
+- New GAB: Warlock's Drain Soul when the enemy has low HP, optional
+- The Drain Soul option is available for Wrath Classic only
+- Additional GAB: Warrior's Overpower in any stance, optional
+- Additional GAB: Warrior's Revenge in any stance, optional
+- Additional GAB: Warrior's Execute in any stance, optional
+
+Please enter /sao to enable or disable these options
 
 #### v0.9.0 (2022-05-01)
 

--- a/classes/warlock.lua
+++ b/classes/warlock.lua
@@ -153,7 +153,7 @@ local function loadOptions(self)
     self:AddOverlayOption(empoweredImpTalent, empoweredImpBuff);
 
     if DrainSoulHandler.initialized then
-        self:AddGlowingOption(nil, DrainSoulHandler.fakeSpellID, drainSoul, nil, string.format("< %s", string.format(HEALTH_COST_PCT, 25)));
+        self:AddGlowingOption(nil, DrainSoulHandler.fakeSpellID, drainSoul, nil, string.format(string.format(HEALTH_COST_PCT, "<%s%"), 25));
     end
     self:AddGlowingOption(nightfallTalent, nightfallBuff, shadowBolt --[[, akaShadowTrance]]);
     self:AddGlowingOption(backlashTalent, backlashBuff, shadowBolt);

--- a/classes/warlock.lua
+++ b/classes/warlock.lua
@@ -121,6 +121,7 @@ local function loadOptions(self)
     local shadowBolt = 686;
     local incinerate = 29722;
     local soulFire = 6353;
+    local drainSoul = 1120;
 
     local nightfallBuff = 17941;
     local nightfallTalent = 18094;
@@ -145,6 +146,9 @@ local function loadOptions(self)
     self:AddOverlayOption(decimationTalent, decimationBuff2);
     self:AddOverlayOption(empoweredImpTalent, empoweredImpBuff);
 
+    if DrainSoulHandler.initialized then
+        self:AddGlowingOption(nil, DrainSoulHandler.fakeSpellID, drainSoul, nil, string.format("< %s", string.format(HEALTH_COST_PCT, 25)));
+    end
     self:AddGlowingOption(nightfallTalent, nightfallBuff, shadowBolt --[[, akaShadowTrance]]);
     self:AddGlowingOption(backlashTalent, backlashBuff, shadowBolt);
     self:AddGlowingOption(backlashTalent, backlashBuff, incinerate);

--- a/classes/warlock.lua
+++ b/classes/warlock.lua
@@ -52,7 +52,13 @@ local function customLogin(self, ...)
         local spellID = 1120;
         local spellName = GetSpellInfo(spellID);
         if (spellName) then
-            self:RegisterGlowIDs({ (spellName) });
+            -- Must register glowing buttons manually, because Drain Soul is not registered by an aura/counter/etc.
+            self:RegisterGlowIDs({ spellName });
+            local allSpellIDs = self:GetSpellIDsByName(spellName);
+            for _, oneSpellID in ipairs(allSpellIDs) do
+                self:AwakeButtonsBySpellID(oneSpellID);
+            end
+            -- Initialize handler
             DrainSoulHandler:init(spellID, spellName);
         end
     end

--- a/options/defaults.lua
+++ b/options/defaults.lua
@@ -267,6 +267,9 @@ SAO.defaults = {
                 [63167] = { -- Decimation
                     [6353] = true, -- Soul Fire
                 },
+                [1001120] = { -- Drain Soul, execute phase
+                    [1120] = false, -- Drain Soul
+                },
             },
         },
         ["WARRIOR"] = {


### PR DESCRIPTION
Implements and closes #95.

New option for Warlocks: glowing button for Drain Soul when the target has 25% health or less.

This option is available in Wrath Classic only, because the damage bonus of Drain Soul on low health enemies was introduced in Wrath of the Lich King.