### PR TITLE
Taste for Blood

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,15 +1,17 @@
 ## SpellActivationOverlay Changelog
 
-#### v0.9.3 (2022-08-31)
+#### v0.9.3 (2023-09-01)
 
 - Druid's Omen of Clarity was no longer working since Classic Era last patch
+- New GAB: Warrior's Overpower button glows during Taste for Blood
+- Taste for Blood will make the Overpower button glow in any stance
 
-#### v0.9.2 (2022-06-21)
+#### v0.9.2 (2023-06-21)
 
 - Bump in TOC file for Trial of the Grand Crusader patch
 - The options window is compatible with the new settings UI
 
-#### v0.9.1 (2022-05-28)
+#### v0.9.1 (2023-05-28)
 
 - Mage's Clearcasting is now enabled by default on Classic Era
 - Mage's Clearcasting has been scaled to 100% (down from 150%) on Classic Era
@@ -21,14 +23,14 @@
 
 Please enter /sao to enable or disable these options
 
-#### v0.9.0 (2022-05-01)
+#### v0.9.0 (2023-05-01)
 
 - Support for Classic Era, although many WotLK spells and talents are missing
 - Mage's Heating Up effect is now hidden when the talent is lost e.g., respec
 - Fixed an issue where paladin and warrior buttons would sometimes not glow
 - The addon should now use a bit less CPU than before
 
-#### v0.8.4 (2022-04-28)
+#### v0.8.4 (2023-04-28)
 
 - New SAO: Druid's Wrath of Elune (4p set bonus of PvP season 5-6-7-8)
 - New SAO: Druid's Elune's Wrath (4p set bonus of tier 8)
@@ -38,7 +40,7 @@ Please enter /sao to enable or disable these options
 
 Enter /sao to enable or disable these options
 
-#### v0.8.3 (2022-01-29)
+#### v0.8.3 (2023-01-29)
 
 - Glowing buttons work again with ProjectAzilroka, after Ulduar patch
 - Mage's Heating Up works again with ProjectAzilroka, after Ulduar patch
@@ -46,7 +48,7 @@ Enter /sao to enable or disable these options
 - These fixes also apply to addons embedding an outdated LibButtonGlow
 - If there is no fallback solution, glowing buttons are temporarily disabled
 
-#### v0.8.2 (2022-01-18)
+#### v0.8.2 (2023-01-18)
 
 - Bump in TOC file for Ulduar patch
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 - Bump in TOC file for Classic Hardcore patch
 - Druid's Omen of Clarity was no longer working since Classic Era last patch
+- Warrior's Overpower button could glow for too long after the target dodged
 - Warrior's Overpower button glows during Taste for Blood
 - The 'baseline' Overpower can only be cast on the target who dodged
 - Taste for Blood, on the other hand, allows to cast Overpower on any target

--- a/changelog.md
+++ b/changelog.md
@@ -1,10 +1,16 @@
 ## SpellActivationOverlay Changelog
 
-#### v0.9.3 (2023-09-01)
+#### v0.9.3 (2023-09-02)
 
+- Bump in TOC file for Classic Hardcore patch
 - Druid's Omen of Clarity was no longer working since Classic Era last patch
-- New GAB: Warrior's Overpower button glows during Taste for Blood
-- Taste for Blood will make the Overpower button glow in any stance
+- Warrior's Overpower button glows during Taste for Blood
+- The 'baseline' Overpower can only be cast on the target who dodged
+- Taste for Blood, on the other hand, allows to cast Overpower on any target
+- Taste for Blood is available on Wrath Classic only
+
+The bug that happened to druids may also happen to other classes
+Please report bugs to the addon's Discord, GitHub or CurseForge
 
 #### v0.9.2 (2023-06-21)
 

--- a/classes/warrior.lua
+++ b/classes/warrior.lua
@@ -2,6 +2,7 @@ local AddonName, SAO = ...
 
 -- Optimize frequent calls
 local CombatLogGetCurrentEventInfo = CombatLogGetCurrentEventInfo
+local GetShapeshiftForm = GetShapeshiftForm
 local UnitCanAttack = UnitCanAttack
 local UnitGUID = UnitGUID
 local UnitHealth = UnitHealth
@@ -87,6 +88,77 @@ local OverpowerHandler = {
             self:dodge(destGUID);
         elseif event == "SPELL_CAST_SUCCESS" and select(13, ...) == self.spellName then
             self:overpower();
+        end
+    end,
+}
+
+--[[
+    OPTFBHandler guesses when Overpower is available,
+    specifically for Taste for Blood
+
+    This must be a different handler than OverpowerHandler.
+    Because Taste for Blood does not have a target requirement,
+    the glow/unglow reasons are quite different, and trying
+    to combine them into a single handler would be a mess.
+
+    The following condition must be met:
+    - the player gains the Taste for Blood effect
+
+    This stops if:
+    - the player loses the Taste for Blood effect
+    
+    The player may lose the effect because Overpower was cast,
+    or because the effect faded after its full duration
+
+    If the Taste for Blood effect is refreshed before Overpower
+    was cast, it will not re-glow the button
+]]
+local OPTFBHandler = {
+
+    initialized = false,
+
+    -- Variables
+
+    buffID = 60503,
+    hasBuff = nil,
+
+    -- Methods
+
+    init = function(self, id, name)
+        SAO.GlowInterface:bind(self);
+        self:initVars(id, name, 2, nil, {
+            -- Must be the same variant values as OverpowerHandler
+            -- Because OPTFBHandler and OverpowerHandler share the same optionID
+            SAO:StanceVariantValue({ 1 }),
+            SAO:StanceVariantValue({ 1, 2, 3 }),
+        }, function(option)
+            -- Unlike other warrior handlers, this handler may be active with "stance:1"
+            return option == "stance:1/2/3" or GetShapeshiftForm() == 1
+        end);
+
+        self.hasBuff = SAO:FindPlayerAuraByID(self.buffID);
+        if self.hasBuff then
+            self:glow();
+        end
+
+        self.initialized = true;
+    end,
+
+    cleu = function(self, ...)
+        local _, event, _, _, _, _, _, destGUID = ...;
+        if destGUID ~= UnitGUID("player") then return end
+        if (event:sub(0,11) ~= "SPELL_AURA_") then return end
+        local spellID, spellName = select(12, CombatLogGetCurrentEventInfo());
+
+        if event == "SPELL_AURA_APPLIED" and SAO:IsSpellIdentical(spellID, spellName, self.buffID) then
+            if not self.hasBuff then
+                self.hasBuff = true;
+                self:glow();
+            end
+        elseif event == "SPELL_AURA_REMOVED" and SAO:IsSpellIdentical(spellID, spellName, self.buffID) then
+            -- Always unglow, even if not needed. Better unglow too much than not enough.
+            self.hasBuff = false;
+            self:unglow();
         end
     end,
 }
@@ -233,6 +305,7 @@ local function customLogin(self, ...)
     local overpowerName = GetSpellInfo(overpower);
     if (overpowerName) then
         OverpowerHandler:init(overpower, overpowerName);
+        OPTFBHandler:init(overpower, overpowerName);
     end
 
     local revenge = 6572;
@@ -251,6 +324,10 @@ end
 local function customCLEU(self, ...)
     if OverpowerHandler.initialized then
         OverpowerHandler:cleu(CombatLogGetCurrentEventInfo());
+    end
+
+    if OPTFBHandler.initialized then
+        OPTFBHandler:cleu(CombatLogGetCurrentEventInfo());
     end
 
     if RevengeHandler.initialized then
@@ -275,7 +352,6 @@ local function unitHealth(self, ...)
 end
 
 local function registerClass(self)
-    local tasteforBlood = 60503;
     local overpower = 7384;
     local execute = 5308;
     local revenge = 6572;
@@ -286,9 +362,6 @@ local function registerClass(self)
     self:RegisterAura("bloodsurge", 0, 46916, "blood_surge", "Top", 1, 255, 255, 255, true, { (GetSpellInfo(slam)) });
     self:RegisterAura("sudden_death", 0, 52437, "sudden_death", "Left + Right (Flipped)", 1, 255, 255, 255, true, { (GetSpellInfo(execute)) });
     self:RegisterAura("sword_and_board", 0, 50227, "sword_and_board", "Left + Right (Flipped)", 1, 255, 255, 255, true, { (GetSpellInfo(shieldSlam)) });
-
-    -- Taste for Blood
-    self:RegisterAura("taste_for_blood", 0, tasteforBlood, "blood_surge", "Top", 0, 0, 0, 0, false, { (GetSpellInfo(overpower)) });
 
     -- Overpower
     self:RegisterAura("overpower", 0, overpower, nil, "", 0, 0, 0, 0, false, { (GetSpellInfo(overpower)) });
@@ -308,9 +381,7 @@ local function registerClass(self)
 end
 
 local function loadOptions(self)
-    local overpower = 7384;
     local execute = 5308;
-    -- local revenge = 6572;
     local victoryRush = 34428;
     local slam = 1464;
     local shieldSlam = 23922;
@@ -344,7 +415,6 @@ local function loadOptions(self)
     self:AddGlowingOption(suddenDeathTalent, suddenDeathBuff, execute);
     self:AddGlowingOption(bloodsurgeTalent, bloodsurgeBuff, slam);
     self:AddGlowingOption(swordAndBoardTalent, swordAndBoardBuff, shieldSlam);
-    self:AddGlowingOption(tasteforBloodTalent, tasteforBloodBuff, overpower)
 end
 
 SAO.Class["WARRIOR"] = {

--- a/classes/warrior.lua
+++ b/classes/warrior.lua
@@ -275,7 +275,7 @@ local function unitHealth(self, ...)
 end
 
 local function registerClass(self)
-    -- local tasteforBlood = 60503; -- Unused as of now, might be used in the future.
+    local tasteforBlood = 60503;
     local overpower = 7384;
     local execute = 5308;
     local revenge = 6572;
@@ -286,6 +286,9 @@ local function registerClass(self)
     self:RegisterAura("bloodsurge", 0, 46916, "blood_surge", "Top", 1, 255, 255, 255, true, { (GetSpellInfo(slam)) });
     self:RegisterAura("sudden_death", 0, 52437, "sudden_death", "Left + Right (Flipped)", 1, 255, 255, 255, true, { (GetSpellInfo(execute)) });
     self:RegisterAura("sword_and_board", 0, 50227, "sword_and_board", "Left + Right (Flipped)", 1, 255, 255, 255, true, { (GetSpellInfo(shieldSlam)) });
+
+    -- Taste for Blood
+    self:RegisterAura("taste_for_blood", 0, tasteforBlood, "blood_surge", "Top", 0, 0, 0, 0, false, { (GetSpellInfo(overpower)) });
 
     -- Overpower
     self:RegisterAura("overpower", 0, overpower, nil, "", 0, 0, 0, 0, false, { (GetSpellInfo(overpower)) });
@@ -305,7 +308,7 @@ local function registerClass(self)
 end
 
 local function loadOptions(self)
-    -- local overpower = 7384;
+    local overpower = 7384;
     local execute = 5308;
     -- local revenge = 6572;
     local victoryRush = 34428;
@@ -321,6 +324,8 @@ local function loadOptions(self)
     local swordAndBoardBuff = 50227;
     local swordAndBoardTalent = 46951;
 
+    local tasteforBloodBuff = 60503;
+    local tasteforBloodTalent = 56636;
 
     self:AddOverlayOption(suddenDeathTalent, suddenDeathBuff);
     self:AddOverlayOption(bloodsurgeTalent, bloodsurgeBuff);
@@ -339,6 +344,7 @@ local function loadOptions(self)
     self:AddGlowingOption(suddenDeathTalent, suddenDeathBuff, execute);
     self:AddGlowingOption(bloodsurgeTalent, bloodsurgeBuff, slam);
     self:AddGlowingOption(swordAndBoardTalent, swordAndBoardBuff, shieldSlam);
+    self:AddGlowingOption(tasteforBloodTalent, tasteforBloodBuff, overpower)
 end
 
 SAO.Class["WARRIOR"] = {

--- a/classes/warrior.lua
+++ b/classes/warrior.lua
@@ -72,10 +72,14 @@ local OverpowerHandler = {
         if not self.targetGuid then return end
 
         if self.glowing and UnitGUID("target") ~= self.targetGuid then
-            self:unglow();
+            self:unglow(true);
         elseif not self.glowing and UnitGUID("target") == self.targetGuid then
-            self:glow();
+            self:glow(true);
         end
+    end,
+
+    onTimeout = function(self)
+        self.targetGuid = nil;
     end,
 
     cleu = function(self, ...)

--- a/components/util.lua
+++ b/components/util.lua
@@ -117,7 +117,11 @@ SAO.GlowInterface = {
         -- IDs
         self.spellID = id;
         self.spellName = name;
-        self.auraID = id + (separateAuraID and 1000000 or 0); -- 1M ought to be enough for anybody
+        local shiftID = separateAuraID and 1000000 or 0; -- 1M ought to be enough for anybody
+        if type(separateAuraID) == 'number' then
+            shiftID = shiftID * separateAuraID;
+        end
+        self.auraID = id + shiftID;
         self.optionID = id;
 
         -- Glowing state

--- a/components/util.lua
+++ b/components/util.lua
@@ -136,14 +136,18 @@ SAO.GlowInterface = {
         self.optionTestFunc = self.variants and optionTestFunc or nil;
     end,
 
-    glow = function(self)
+    -- Make the button glow if the glowing button is enabled in options
+    -- When the button glows, start or restart the timer, unless either condtion is true
+    -- - the glowing button was not initialized with a duration
+    -- - the skipTimer argument is true
+    glow = function(self, skipTimer)
         if type(self.optionTestFunc) ~= 'function' or self.optionTestFunc(self.variants.getOption()) then
             -- Let it glow
             SAO:AddGlow(self.auraID, { self.spellName });
             self.glowing = true;
 
             -- Start timer if needed
-            if self.maxDuration then
+            if self.maxDuration and not skipTimer then
                 local tolerance = 0.2;
                 self.vanishTime = GetTime() + self.maxDuration - tolerance;
                 C_Timer.After(self.maxDuration, function()
@@ -153,15 +157,23 @@ SAO.GlowInterface = {
         end
     end,
 
-    unglow = function(self)
+    -- Make the button unglow
+    -- The button unglows even if it was disabled in options; better unglow too much than not enough
+    -- The vanish timer, if any, is reset unless skipTimer is true
+    unglow = function(self, skipTimer)
         SAO:RemoveGlow(self.auraID);
         self.glowing = false;
-        self.vanishTime = nil;
+        if not skipTimer then
+            self.vanishTime = nil;
+        end
     end,
 
     timeout = function(self)
         if self.vanishTime and GetTime() > self.vanishTime then
             self:unglow();
+            if type(self.onTimeout) == 'function' then
+                self:onTimeout()
+            end
         end
     end,
 }

--- a/options/defaults.lua
+++ b/options/defaults.lua
@@ -283,6 +283,11 @@ SAO.defaults = {
                 [50227] = { -- Sword and Board
                     [0] = true,
                 },
+                [60503] = { -- Taste for Blood
+                    -- Not used in practice as a spell alert
+                    -- Even unused, it helps with alertless glowing buttons
+                    [0] = false,
+                },
             },
             glow = {
                 [7384] = { -- Overpower
@@ -305,6 +310,9 @@ SAO.defaults = {
                 },
                 [50227] = { -- Sword and Board
                     [23922] = true, -- Shield Slam
+                },
+                [60503] = { -- Taste for Blood
+                    [7384] = true, -- Overpower
                 },
             },
         },

--- a/options/defaults.lua
+++ b/options/defaults.lua
@@ -283,11 +283,6 @@ SAO.defaults = {
                 [50227] = { -- Sword and Board
                     [0] = true,
                 },
-                [60503] = { -- Taste for Blood
-                    -- Not used in practice as a spell alert
-                    -- Even unused, it helps with alertless glowing buttons
-                    [0] = false,
-                },
             },
             glow = {
                 [7384] = { -- Overpower
@@ -310,9 +305,6 @@ SAO.defaults = {
                 },
                 [50227] = { -- Sword and Board
                     [23922] = true, -- Shield Slam
-                },
-                [60503] = { -- Taste for Blood
-                    [7384] = true, -- Overpower
                 },
             },
         },


### PR DESCRIPTION
Overpower button now also glows while the warrior is under the effect of the Taste for Blood buff. Implements #104, at least partially.

Also fixes a bug that was probably there already, which caused the Overpower glowing button to stay glowing for longer than intended. Fixes #138.