### PR TITLE
Soul Preserver

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -182,7 +182,8 @@
         "GetTalentTabInfo",
         "UNKNOWN",
         "Settings",
-        "UnitExists"
+        "UnitExists",
+        "GetItemInfo"
     ],
     "workbench.colorCustomizations": {
         "activityBar.activeBackground": "#4f71dc",

--- a/SpellActivationOverlay.toc
+++ b/SpellActivationOverlay.toc
@@ -1,8 +1,8 @@
 ## Interface: 30403
-## Title: |TInterface/Icons/Spell_Frost_Stun:16:16:0:0:512:512:64:448:64:448|t SpellActivationOverlay |cffa2f3ff0.9.5|r
+## Title: |TInterface/Icons/Spell_Frost_Stun:16:16:0:0:512:512:64:448:64:448|t SpellActivationOverlay |cffa2f3ff0.9.5-beta|r
 ## Notes: Mimic Spell Activation Overlays from Retail
 ## Author: Vinny
-## Version: 0.9.5
+## Version: 0.9.5-beta
 ## SavedVariables: SpellActivationOverlayDB
 
 # SpellActivationOverlay.lua, SpellActivationOverlay.xml and all textures
@@ -21,6 +21,7 @@ components\aura.lua
 components\counter.lua
 components\events.lua
 components\glow.lua
+components\item.lua
 components\overlay.lua
 components\spell.lua
 components\util.lua

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,9 @@
 ## SpellActivationOverlay Changelog
 
-#### v0.9.5 (2023-11-xx)
+#### v0.9.5-beta (2023-11-xx)
 
 - Buttons should glow correctly when using AzeriteUI
+- New SAOs: Healing Trance / Soul Preserver, for all healing classes
 - New GAB: Hunter's Mongoose Bite (Classic Era only)
 - Warriors can hold 2 charges of Sudden Death thanks to tier 10 set bonus
 - Warriors can hold 2 charges of Bloodsurge thanks to tier 10 set bonus

--- a/classes/druid.lua
+++ b/classes/druid.lua
@@ -251,6 +251,9 @@ local function registerClass(self)
     self:RegisterAura("wrath_of_elune", 0, 46833, "shooting_stars", "Top", 1, 255, 255, 255, true, { starfire }); -- PvP season 5-6-7-8
     self:RegisterAura("elunes_wrath", 0, 64823, "shooting_stars", "Top", 1, 255, 255, 255, true, { starfire }); -- PvE tier 8
 
+    -- Healing Trance / Soul Preserver
+    self:RegisterAuraSoulPreserver("soul_preserver_druid", 60512); -- 60512 = Druid buff
+
     -- Mark textures that aren't marked automatically
     local omenTextureFeral = "feral_omenofclarity";
     local omenTextureResto = "natures_grace";
@@ -310,6 +313,7 @@ local function loadOptions(self)
     self:AddOverlayOption(elunesWrathTalent, elunesWrathBuff);
     self:AddOverlayOption(naturesGraceTalent, naturesGraceBuff, 0, nil, naturesGraceVariants);
     self:AddOverlayOption(predatoryStrikesTalent, predatoryStrikesBuff);
+    self:AddSoulPreserverOverlayOption(60512); -- 60512 = Druid buff
 
     self:AddGlowingOption(lunarEclipseTalent, starfire, starfire);
     self:AddGlowingOption(solarEclipseTalent, wrath, wrath);

--- a/classes/paladin.lua
+++ b/classes/paladin.lua
@@ -34,6 +34,9 @@ local function registerClass(self)
 
     -- Infusion of Light, 2/2 talent points
     self:RegisterAura("infusion_of_light_high", 0, infusionOfLightBuff2, "daybreak", "Left + Right (Flipped)", 1, 255, 255, 255, true, { flashOfLight, holyLight });
+
+    -- Healing Trance / Soul Preserver
+    self:RegisterAuraSoulPreserver("soul_preserver_paladin", 60513); -- 60513 = Paladin buff
 end
 
 local function loadOptions(self)
@@ -52,6 +55,7 @@ local function loadOptions(self)
 
     self:AddOverlayOption(infusionOfLightTalent, infusionOfLightBuff2);
     self:AddOverlayOption(artOfWarTalent, artOfWarBuff2);
+    self:AddSoulPreserverOverlayOption(60513); -- 60513 = Paladin buff
 
     self:AddGlowingOption(nil, how, how);
     self:AddGlowingOption(infusionOfLightTalent, infusionOfLightBuff2, flashOfLight);

--- a/classes/priest.lua
+++ b/classes/priest.lua
@@ -29,6 +29,9 @@ local function registerClass(self)
             self:RegisterAura(auraName, nbStacks, auraBuff, "serendipity", "Top", scale, 255, 255, 255, pulse, glowIDs);
         end
     end
+
+    -- Healing Trance / Soul Preserver
+    self:RegisterAuraSoulPreserver("soul_preserver_priest", 60514); -- 60514 = Priest buff
 end
 
 local function loadOptions(self)
@@ -49,6 +52,7 @@ local function loadOptions(self)
     self:AddOverlayOption(surgeOfLightTalent, surgeOfLightBuff);
     self:AddOverlayOption(serendipityTalent, serendipityBuff3, 0, oneOrTwoStacks, nil, 2); -- setup any stacks, test with 2 stacks
     self:AddOverlayOption(serendipityTalent, serendipityBuff3, 3); -- setup 3 stacks
+    self:AddSoulPreserverOverlayOption(60514); -- 60514 = Priest buff
 
     self:AddGlowingOption(surgeOfLightTalent, surgeOfLightBuff, smite);
     self:AddGlowingOption(surgeOfLightTalent, surgeOfLightBuff, flashHeal);

--- a/classes/shaman.lua
+++ b/classes/shaman.lua
@@ -34,6 +34,9 @@ local function registerClass(self)
     self:RegisterAura("tidal_waves_1", 1, 53390, "high_tide", "Left (CCW)", 0.8, 255, 255, 255, true, tidalSpells);
     self:RegisterAura("tidal_waves_2", 2, 53390, "high_tide", "Left (CCW)", 0.8, 255, 255, 255, true, tidalSpells);
     self:RegisterAura("tidal_waves_2", 2, 53390, "high_tide", "Right (CW)", 0.8, 255, 255, 255, true); -- no need to re-glow tidalSpells for right texture
+
+    -- Healing Trance / Soul Preserver
+    self:RegisterAuraSoulPreserver("soul_preserver_shaman", 60515); -- 60515 = Shaman buff
 end
 
 local function loadOptions(self)
@@ -60,6 +63,7 @@ local function loadOptions(self)
     self:AddOverlayOption(maelstromWeaponTalent, maelstromWeaponBuff, 0, oneToFourStacks, nil, 4); -- setup any stacks, test with 4 stacks
     self:AddOverlayOption(maelstromWeaponTalent, maelstromWeaponBuff, 5); -- setup 5 stacks
     self:AddOverlayOption(tidalWavesTalent, tidalWavesBuff, 0, nil, nil, 2); -- setup any stacks, test with 2 stacks
+    self:AddSoulPreserverOverlayOption(60515); -- 60515 = Shaman buff
 
     self:AddGlowingOption(maelstromWeaponTalent, maelstromWeaponBuff, lightningBolt, fiveStacks);
     self:AddGlowingOption(maelstromWeaponTalent, maelstromWeaponBuff, chainLightning, fiveStacks);

--- a/components/item.lua
+++ b/components/item.lua
@@ -1,0 +1,17 @@
+local AddonName, SAO = ...
+
+-- Get icon and label of an item
+function SAO.GetItemText(self, itemID)
+    local name,_,_,_,_,_,_,_,_,icon = GetItemInfo(itemID);
+    if name then
+        return "|T"..icon..":0|t "..name;
+    end
+end
+
+function SAO.AddItemOverlayOption(self, spellID, itemID, projectID)
+    if WOW_PROJECT_ID == projectID then
+        local itemText = self:GetItemText(itemID);
+        self:AddOverlayOption(spellID, spellID, 0, itemText);
+    end
+end
+

--- a/components/item.lua
+++ b/components/item.lua
@@ -15,3 +15,13 @@ function SAO.AddItemOverlayOption(self, spellID, itemID, projectID)
     end
 end
 
+function SAO.RegisterAuraSoulPreserver(self, label, spellID)
+    if WOW_PROJECT_ID == WOW_PROJECT_WRATH_CLASSIC then
+        self:RegisterAura(label, 0, spellID, "genericarc_05", "Left + Right (Flipped)", 1.5, 192, 192, 192, false);
+    end
+end
+
+function SAO.AddSoulPreserverOverlayOption(self, spellID)
+    -- Spell is specific to each class, item is the same for everyone
+    self:AddItemOverlayOption(spellID, 37111, WOW_PROJECT_WRATH_CLASSIC);
+end

--- a/options/defaults.lua
+++ b/options/defaults.lua
@@ -196,6 +196,9 @@ SAO.defaults = {
                     [3] = true,  -- 3 stacks
                     [0] = false, -- any stacks but 3
                 },
+                [60514] = { -- Healing Trance / Soul Preserver
+                    [0] = false,
+                },
             },
             glow = {
                 [33151] = { -- Surge of Light

--- a/options/defaults.lua
+++ b/options/defaults.lua
@@ -172,6 +172,9 @@ SAO.defaults = {
                 [59578] = { -- The Art of War (2/2)
                     [0] = true,
                 },
+                [60513] = { -- Healing Trance / Soul Preserver
+                    [0] = false,
+                },
             },
             glow = {
                 [24275] = { -- Hammer of Wrath

--- a/options/defaults.lua
+++ b/options/defaults.lua
@@ -232,6 +232,9 @@ SAO.defaults = {
                 [53390] = { -- Tidal Waves
                     [0] = false, -- any stacks
                 },
+                [60515] = { -- Healing Trance / Soul Preserver
+                    [0] = false,
+                },
             },
             glow = {
                 [53817] = { -- Maelstorm Weapon

--- a/options/defaults.lua
+++ b/options/defaults.lua
@@ -48,6 +48,9 @@ SAO.defaults = {
                 [69369] = { -- Predatory Strikes
                     [0] = true,
                 },
+                [60512] = { -- Healing Trance / Soul Preserver
+                    [0] = false,
+                },
             },
             glow = {
                 [2912] = { -- Starfire


### PR DESCRIPTION
Add Soul Preserver options for each class. Implements #94 and beyond. Extends #97 which was a fair attempt, although limited to druids and hardcoded.