### PR TITLE
Adding support for Blood Surge in Season of Discovery

### DIFF
--- a/_script/package.sh
+++ b/_script/package.sh
@@ -78,7 +78,6 @@ molten_core
 imp_empowerment
 art_of_war
 lock_and_load
-blood_surge
 brain_freeze
 maelstrom_weapon_2
 sudden_death

--- a/classes/warrior.lua
+++ b/classes/warrior.lua
@@ -364,6 +364,8 @@ local function registerClass(self)
     local shieldSlam = 23922;
     local victoryRushSoD = 402927;
     local ragingBlowSoD = 402911;
+    local bloodSurgeSoD = 413380;
+    local bloodSurgeSoDBuff = 413399;
 
     for stacks = 1, 2 do -- Bloodsurge and Sudden Death may have several charges, due to T10 4pc
         self:RegisterAura("bloodsurge_"..stacks, stacks, 46916, "blood_surge", "Top", 1, 255, 255, 255, true, { (GetSpellInfo(slam)) });
@@ -398,6 +400,11 @@ local function registerClass(self)
         self:RegisterAura("raging_blow", 0, ragingBlowSoD, "raging_blow", "Left + Right (Flipped)", 1, 255, 255, 255, true, { (GetSpellInfo(ragingBlowSoD)) });
         self:RegisterCounter("raging_blow"); -- Must match name from above call
     end
+
+    -- Blood Surge (Season of Discovery)
+    if self.IsSoD() then
+        self:RegisterAura("blood_surge", 0, bloodSurgeSoD, "blood_surge", "Top", 1, 255, 255, 255, true, { (GetSpellInfo(slam)) });
+    end
 end
 
 local function loadOptions(self)
@@ -419,13 +426,17 @@ local function loadOptions(self)
     local tasteforBloodTalent = 56636;
 
     local victoryRushSoD = 402927;
+    
     local ragingBlowSoD = 402911;
+
+    local bloodSurgeSoDBuff = 413380;
 
     self:AddOverlayOption(suddenDeathTalent, suddenDeathBuff);
     self:AddOverlayOption(bloodsurgeTalent, bloodsurgeBuff);
     self:AddOverlayOption(swordAndBoardTalent, swordAndBoardBuff);
     if self.IsSoD() then
         self:AddOverlayOption(ragingBlowSoD, ragingBlowSoD);
+        self:AddOverlayOption(bloodSurgeSoDBuff, bloodSurgeSoDBuff);
     end
 
     if OverpowerHandler.initialized then
@@ -441,6 +452,7 @@ local function loadOptions(self)
     if self.IsSoD() then
         self:AddGlowingOption(nil, victoryRushSoD, victoryRushSoD);
         self:AddGlowingOption(nil, ragingBlowSoD, ragingBlowSoD);
+        self:AddGlowingOption(bloodSurgeSoDBuff, bloodSurgeSoDBuff, slam);
     end
     self:AddGlowingOption(suddenDeathTalent, suddenDeathBuff, execute);
     self:AddGlowingOption(bloodsurgeTalent, bloodsurgeBuff, slam);

--- a/classes/warrior.lua
+++ b/classes/warrior.lua
@@ -365,7 +365,6 @@ local function registerClass(self)
     local victoryRushSoD = 402927;
     local ragingBlowSoD = 402911;
     local bloodSurgeSoD = 413380;
-    local bloodSurgeSoDBuff = 413399;
 
     for stacks = 1, 2 do -- Bloodsurge and Sudden Death may have several charges, due to T10 4pc
         self:RegisterAura("bloodsurge_"..stacks, stacks, 46916, "blood_surge", "Top", 1, 255, 255, 255, true, { (GetSpellInfo(slam)) });
@@ -426,9 +425,7 @@ local function loadOptions(self)
     local tasteforBloodTalent = 56636;
 
     local victoryRushSoD = 402927;
-    
     local ragingBlowSoD = 402911;
-
     local bloodSurgeSoDBuff = 413380;
 
     self:AddOverlayOption(suddenDeathTalent, suddenDeathBuff);


### PR DESCRIPTION
Made changes to warrior.lua and package.sh to add support for Blood Surge procs in Season of Discovery.

In Game Screenshots...

1. ...of the addon configuration UI:
![image](https://github.com/ennvina/spellactivationoverlay/assets/6124746/c79e6ad7-ce5b-4320-93c3-8c47cd6a6b77)

2. ...of the aura:
![image](https://github.com/ennvina/spellactivationoverlay/assets/6124746/172fa364-5bec-422a-825d-6c0862cc0c72)

3. ...of the icon glow: 
![image](https://github.com/ennvina/spellactivationoverlay/assets/6124746/c5530793-13c2-40f7-953c-ce77ed4a0db9)

4. ...of the console debug log output:
![image](https://github.com/ennvina/spellactivationoverlay/assets/6124746/981dc144-c808-4614-af8b-ab035c263591)

