### PR TITLE
Rolling Thunder followup

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -193,7 +193,9 @@
         "C_Engraving",
         "COMBATLOG_HIGHLIGHT_ABILITY",
         "AVAILABLE",
-        "ON_COOLDOWN"
+        "ON_COOLDOWN",
+        "IsSpellKnownOrOverridesKnown",
+        "C_UnitAuras"
     ],
     "workbench.colorCustomizations": {
         "activityBar.activeBackground": "#4f71dc",

--- a/SpellActivationOverlay.toc
+++ b/SpellActivationOverlay.toc
@@ -1,8 +1,8 @@
 ## Interface: 30403
-## Title: |TInterface/Icons/Spell_Frost_Stun:16:16:0:0:512:512:64:448:64:448|t SpellActivationOverlay |cffa2f3ff1.3.0|r
+## Title: |TInterface/Icons/Spell_Frost_Stun:16:16:0:0:512:512:64:448:64:448|t SpellActivationOverlay |cffa2f3ff1.3.1|r
 ## Notes: Mimic Spell Activation Overlays from Modern World of Warcraft
 ## Author: Vinny/Ennvina
-## Version: 1.3.0
+## Version: 1.3.1
 ## SavedVariables: SpellActivationOverlayDB
 
 # SpellActivationOverlay.lua, SpellActivationOverlay.xml and all textures were created by Blizzard Entertainment, Inc.

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,16 @@
 ## SpellActivationOverlay Changelog
 
+#### v1.3.1 (2024-04-xx)
+
+Shout-out to fellow developer Amanthuul. Thanks!
+
+New runes for Season of Discovery:
+- New SAO: Shaman's Rolling Thunder with 7-9 Lightning Shield stacks
+- New SAO: Shaman's Tidal Waves
+- New GAB: Shaman's Earth Shock, with 7-9 Lightning Shield stacks
+- New GAB: Shaman's Healing Wave, during Tidal Waves
+- New GAB: Shaman's Lesser Healing Wave, during Tidal Waves
+
 #### v1.3.0 (2024-04-17)
 
 Bump in TOC file for Season of Discovery update (Classic Era)

--- a/classes/mage.lua
+++ b/classes/mage.lua
@@ -624,8 +624,8 @@ local function loadOptions(self)
     -- local hotStreakHeatingUpDetails = string.format("%s+%s", heatingUpDetails, hotStreakDetails);
     local hotStreakHeatingUpDetails = string.format("%s %s", STATUS_TEXT_BOTH, ACTION_SPELL_AURA_APPLIED_DOSE);
 
-    local oneToThreeStacks = string.format(CALENDAR_TOOLTIP_DATE_RANGE, "1", string.format(STACKS, 3));
-    local fourStacks = string.format(STACKS, 4);
+    local oneToThreeStacks = self:NbStacks(1, 3);
+    local fourStacks = self:NbStacks(4);
 
     -- Clearcasting variants
     lazyCreateClearcastingVariants(self);

--- a/classes/priest.lua
+++ b/classes/priest.lua
@@ -73,8 +73,8 @@ local function loadOptions(self)
     local serendipityTalent = 63730;
     local serendipitySoDBuff = 413247;
 
-    local oneOrTwoStacks = string.format(CALENDAR_TOOLTIP_DATE_RANGE, "1", string.format(STACKS, 2));
-    local threeStacks = string.format(STACKS, 3);
+    local oneOrTwoStacks = self:NbStacks(1, 2);
+    local threeStacks = self:NbStacks(3);
 
     if not self.IsEra() then
         self:AddOverlayOption(surgeOfLightTalent, surgeOfLightBuff);

--- a/classes/shaman.lua
+++ b/classes/shaman.lua
@@ -1,7 +1,7 @@
 local AddonName, SAO = ...
 
 -- Detect Rolling Thunder stacks
-local rollingThunderHandler = {
+local RollingThunderHandler = {
     -- Constants
     lightningShield = {324, 325, 905, 945, 8134, 10431, 10432},
     fakeSpellID = 324+1000000, -- For option testing
@@ -98,20 +98,20 @@ local rollingThunderHandler = {
 local function checkRollingThunderRuneAndLightningSieldStacks(self, ...)
     local RollingThunderEquipped = C_Engraving and SAO:IsSpellLearned(432056);
     if not RollingThunderEquipped then
-        rollingThunderHandler:deactivate();
+        RollingThunderHandler:deactivate();
     else
         -- C_UnitAuras is currently available for Classic Era only
         -- Fortunately, RollingThunderHandler is used only on Season of Discovery
         local aura = C_UnitAuras.GetAuraDataBySpellName("player", GetSpellInfo(324));
         if aura and aura.applications > 6 and not SAO:GetActiveOverlay(324) then
-            rollingThunderHandler:activate(aura.applications);
+            RollingThunderHandler:activate(aura.applications);
         end
     end
 end
 
 local function customCLEU(self, ...)
-    if rollingThunderHandler.initialized then
-        rollingThunderHandler:cleu();
+    if RollingThunderHandler.initialized then
+        RollingThunderHandler:cleu();
     end
 end
 
@@ -166,8 +166,8 @@ local function registerClass(self)
     if self.IsSoD() then
 
         -- Initializing Rolling Thunder handler, only for Season of Discovery
-        if (not rollingThunderHandler.initialized) then
-            rollingThunderHandler:init();
+        if (not RollingThunderHandler.initialized) then
+            RollingThunderHandler:init();
         end
 
         local moltenBlastSoD = 425339;
@@ -238,7 +238,7 @@ local function registerClass(self)
             local auraName = "rolling_thunder_"..lightningShieldStacks;
             local scale = 0.5 + 0.1 * (lightningShieldStacks - 6); -- 60%, 70%, 80%
             local pulse = lightningShieldStacks == 9;
-            self:RegisterAura(auraName, lightningShieldStacks, rollingThunderHandler.fakeSpellID, "fulmination", "Top", scale, 255, 255, 255, pulse, rollingThunderSpells);
+            self:RegisterAura(auraName, lightningShieldStacks, RollingThunderHandler.fakeSpellID, "fulmination", "Top", scale, 255, 255, 255, pulse, rollingThunderSpells);
         end
         -- Tidal Waves SoD
         local tidalSpells = {
@@ -303,9 +303,9 @@ local function loadOptions(self)
         self:AddOverlayOption(moltenBlastSoD, moltenBlastSoD);
         self:AddOverlayOption(maelstromSoD, maelstromSoDBuff, 0, oneToFourStacks, nil, 4); -- setup any stacks, test with 4 stacks
         self:AddOverlayOption(maelstromSoD, maelstromSoDBuff, 5); -- setup 5 stacks
-        self:AddOverlayOption(rollingThunderSoD, lightningShield, 7, nil, nil, nil, rollingThunderHandler.fakeSpellID);
-        self:AddOverlayOption(rollingThunderSoD, lightningShield, 8, nil, nil, nil, rollingThunderHandler.fakeSpellID);
-        self:AddOverlayOption(rollingThunderSoD, lightningShield, 9, nil, nil, nil, rollingThunderHandler.fakeSpellID);
+        self:AddOverlayOption(rollingThunderSoD, lightningShield, 7, nil, nil, nil, RollingThunderHandler.fakeSpellID);
+        self:AddOverlayOption(rollingThunderSoD, lightningShield, 8, nil, nil, nil, RollingThunderHandler.fakeSpellID);
+        self:AddOverlayOption(rollingThunderSoD, lightningShield, 9, nil, nil, nil, RollingThunderHandler.fakeSpellID);
         self:AddOverlayOption(tidalWavesSoDTalent, tidalWavesSoDBuff, 0, nil, nil, 2); -- setup any stacks, test with 2 stacks
     end
 

--- a/classes/shaman.lua
+++ b/classes/shaman.lua
@@ -74,7 +74,7 @@ local RollingThunderHandler = {
         if (hasSAO) then
             local scale = 0.5 + 0.1 * (lightningShieldStacks - 6);
             local pulse = lightningShieldStacks == 9 or nil;
-            SAO:ActivateOverlay(lightningShieldStacks, 324, SAO.TexName["fulmination"], "Top", scale, 255, 255, 255, pulse, nil);
+            SAO:ActivateOverlay(lightningShieldStacks, 324, SAO.TexName["fulmination"], "Top", scale, 255, 255, 255, pulse, pulse);
         end
 
         -- GABs

--- a/classes/shaman.lua
+++ b/classes/shaman.lua
@@ -96,6 +96,10 @@ local RollingThunderHandler = {
 -- Must activate Rolling Thunder after logging or changing runes, if the rune is present on wrists and if there are 7 or more charges or Lightning Shield
 -- This function does not re-activate the effect if already activated
 local function checkRollingThunderRuneAndLightningSieldStacks(self, ...)
+    if not RollingThunderHandler.initialized then
+        return;
+    end
+
     local RollingThunderEquipped = C_Engraving and SAO:IsSpellLearned(432056);
     if not RollingThunderEquipped then
         RollingThunderHandler:deactivate();

--- a/classes/shaman.lua
+++ b/classes/shaman.lua
@@ -16,7 +16,7 @@ local RollingThunderHandler = {
     init = function(self)
         -- Fetch spell name of Earth Shock
         -- Instead, we could hardcode the list of spell IDs of all ranks, but the spell name is fine
-        table.insert(self.earthShockSpells, GetSpellInfo(8042));
+        table.insert(self.earthShockSpells, (GetSpellInfo(8042)));
 
         -- Keep spell ID of Lightning Shield ranks only for ranks known at the current expansion
         for _, id in pairs(self.lightningShield) do

--- a/classes/shaman.lua
+++ b/classes/shaman.lua
@@ -275,9 +275,9 @@ local function loadOptions(self)
     local tidalWavesSoDBuff = 432041;
     local tidalWavesSoDTalent = 432233;
 
-    local oneToFourStacks = string.format(CALENDAR_TOOLTIP_DATE_RANGE, "1", string.format(STACKS, 4));
-    local fiveStacks = string.format(STACKS, 5);
-    local sevenToNineStacks = string.format(CALENDAR_TOOLTIP_DATE_RANGE, "7", string.format(STACKS, 9));
+    local oneToFourStacks = self:NbStacks(1, 4);
+    local fiveStacks = self:NbStacks(5);
+    local sevenToNineStacks = self:NbStacks(7, 9);
 
     if self.IsEra() then
         -- Elemental Focus has 1 charge on Classic Era

--- a/components/rune.lua
+++ b/components/rune.lua
@@ -26,6 +26,7 @@ local function initRuneMapping()
             foundRune = true;
         end
     end
+    SAO:Trace(Module, "initRuneMapping foundRune == "..tostring(foundRune));
     runeMapping.initialized = foundRune;
 end
 
@@ -38,7 +39,6 @@ function SAO.GetRuneFromSpell(self, spellID)
 
     return runeMapping[spellID];
 end
-
 
 -- Track rune updates
 if SAO.IsSoD() then

--- a/components/util.lua
+++ b/components/util.lua
@@ -50,6 +50,16 @@ function SAO.GetGCD(self)
     end
 end
 
+-- Utility function to write a formatted 'number of stacks' text, translated with the client's locale
+-- SAO:NbStacks(4) -- "4 Stacks"
+-- SAO:NbStacks(7,9) -- "7-9 Stacks"
+function SAO.NbStacks(self, minStacks, maxStacks)
+    if maxStacks then
+        return string.format(CALENDAR_TOOLTIP_DATE_RANGE, tostring(minStacks), string.format(STACKS, maxStacks));
+    end
+    return string.format(STACKS, minStacks);
+end
+
 -- Utility function to assume times are identical or almost identical
 function SAO.IsTimeAlmostEqual(self, t1, t2, delta)
 	return t1-delta < t2 and t2 < t1+delta;

--- a/options/defaults.lua
+++ b/options/defaults.lua
@@ -335,7 +335,7 @@ SAO.defaults = {
                     [8] = false,
                     [9] = true,
                 },
-                [432041] = { -- Tidal Waves SoD
+                [432041] = { -- Tidal Waves (Season of Discovery)
                     [0] = false, -- any stacks
                 },
             },
@@ -343,7 +343,7 @@ SAO.defaults = {
                 [53817] = { -- Maelstrom Weapon
                     [403]   = false, -- Lightning Bolt
                     [421]   = false, -- Chain Lightning
-                    [8004]  = false, -- lesser Healing Wave
+                    [8004]  = false, -- Lesser Healing Wave
                     [331]   = false, -- Healing Wave
                     [1064]  = false, -- Chain Heal
                     [51514] = false, -- Hex
@@ -351,7 +351,7 @@ SAO.defaults = {
                 [408505] = { -- Maelstrom Weapon (Season of Discovery)
                     [403]   = false, -- Lightning Bolt
                     [421]   = false, -- Chain Lightning
-                    [8004]  = false, -- lesser Healing Wave
+                    [8004]  = false, -- Lesser Healing Wave
                     [331]   = false, -- Healing Wave
                     [1064]  = false, -- Chain Heal
                     [408490] = false, -- Lava Burst (Season of Discovery)
@@ -362,7 +362,7 @@ SAO.defaults = {
                     [408490] = false, -- Lava Burst (Season of Discovery)
                 },
                 [53390] = { -- Tidal Waves
-                    [8004] = false, -- lesser Healing Wave
+                    [8004] = false, -- Lesser Healing Wave
                     [331]  = false, -- Healing Wave
                 },
                 [425339]= { -- Molten Blast (Season of Discovery)
@@ -371,8 +371,8 @@ SAO.defaults = {
                 [432056]= { -- Rolling Thunder (Season of Discovery)
                     [8042] = true, -- Rolling Thunder (Season of Discovery)
                 },
-                [432041] = { -- Tidal Waves SoD
-                    [8004] = false, -- lesser Healing Wave
+                [432041] = { -- Tidal Waves (Season of Discovery)
+                    [8004] = false, -- Lesser Healing Wave
                     [331]  = false, -- Healing Wave
                 },
             },

--- a/options/overlayoptions.lua
+++ b/options/overlayoptions.lua
@@ -33,7 +33,7 @@ function SAO.AddOverlayOption(self, talentID, auraID, count, talentSubText, vari
         local spellName, _, spellIcon = GetSpellInfo(talentID);
         text = text.." |T"..spellIcon..":0|t "..spellName;
         if (count and count > 0) then
-            text = text .. " ("..string.format(STACKS, count)..")";
+            text = text .. " ("..SAO:NbStacks(count)..")";
         end
         if (talentSubText) then
             text = text.." ("..talentSubText..")";

--- a/textures/texname.lua
+++ b/textures/texname.lua
@@ -118,9 +118,12 @@ function SAO.MarkTexture(self, texName)
   end
 end
 
--- List fetched from bash: cd textures && ls -1 *.blp | cut -d. -f1 | tr 'A-Z' 'a-z' | awk 'BEGIN{ print "local availableTextures = {" } {printf "  [\"%s\"] = true,\n", $0} END { print "}" }'
+-- List fetched from bash: cd textures && ls -1 *.blp | cut -d. -f1 | tr 'A-Z' 'a-z' | grep -vE '^(mask|maskzero)$' | awk 'BEGIN{ print "local availableTextures = {" } {printf "  [\"%s\"] = true,\n", $0} END { print "}" }'
 local availableTextures = {
   ["arcane_missiles"] = true,
+  ["arcane_missiles_1"] = true,
+  ["arcane_missiles_2"] = true,
+  ["arcane_missiles_3"] = true,
   ["art_of_war"] = true,
   ["backlash"] = true,
   ["bandits_guile"] = true,
@@ -132,6 +135,7 @@ local availableTextures = {
   ["eclipse_sun"] = true,
   ["feral_omenofclarity"] = true,
   ["frozen_fingers"] = true,
+  ["fulmination"] = true,
   ["fury_of_stormrage"] = true,
   ["genericarc_02"] = true,
   ["genericarc_05"] = true,
@@ -148,16 +152,18 @@ local availableTextures = {
   ["maelstrom_weapon_4"] = true,
   ["master_marksman"] = true,
   ["molten_core"] = true,
+  ["monk_serpent"] = true,
   ["natures_grace"] = true,
   ["nightfall"] = true,
   ["predatory_swiftness"] = true,
+  ["raging_blow"] = true,
   ["rime"] = true,
   ["serendipity"] = true,
   ["shooting_stars"] = true,
   ["sudden_death"] = true,
   ["surge_of_light"] = true,
   ["sword_and_board"] = true,
-  ["fulmination"] = true,
+  ["tooth_and_claw"] = true,
 }
 
 -- Global functions, helpful for optimizing package


### PR DESCRIPTION
Follow-up of #196
- fixed a mistake that caused a Lua error for shamans
- fixed an issue that caused the overlay to sometimes not pulse when it should
- Rolling Thunder variables have been renamed and are initialized slightly differently
- now we make sure `SPELLS_CHANGED` is only used when the Rolling Thunder handler is initialized
- improve code maintainability
- describe changes to Changelog