### PR TITLE
Mind Spike (SoD)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,9 +17,11 @@ New effects for Wrath Classic:
 New runes for Season of Discovery:
 - New SAO: Shaman's Rolling Thunder with 7-9 Lightning Shield stacks
 - New SAO: Shaman's Tidal Waves
+- New SAO: Priest's Mind Spike
 - New GAB: Mage's Deep Freeze, during Fingers of Frost
 - New GAB: Mage's Deep Freeze, when the target is Frozen
 - New GAB: Paladin's Divine Storm, as combat-only counter
+- New GAB: Priest's Mind Blast, during Mind Spike at 3 stacks
 - New GAB: Shaman's Earth Shock, with 7-9 Lightning Shield stacks
 - New GAB: Shaman's Healing Wave, during Tidal Waves
 - New GAB: Shaman's Lesser Healing Wave, during Tidal Waves

--- a/classes/priest.lua
+++ b/classes/priest.lua
@@ -64,6 +64,17 @@ local function registerClass(self)
             local glowIDs = nbStacks == 3 and serendipityImprovedSpells or nil;
             self:RegisterAura("serendipity_sod", nbStacks, serendipityBuff, "serendipity", "Top", scale, 255, 255, 255, pulse, glowIDs);
         end
+
+        -- Mind Spike
+        local mindSpikeBuff = 431655;
+        local mindBlast = 8092;
+        local mindSpikeImprovedSpells = { (GetSpellInfo(mindBlast)) };
+        for nbStacks=1,3 do
+            local scale = 0.4 + 0.2 * nbStacks; -- 60%, 80%, 100%
+            local pulse = nbStacks == 3;
+            local glowIDs = nbStacks == 3 and mindSpikeImprovedSpells or nil;
+            self:RegisterAura("mind_spike_sod", nbStacks, mindSpikeBuff, "frozen_fingers", "Left + Right (Flipped)", scale, 160, 60, 220, pulse, glowIDs);
+        end
     end
 end
 
@@ -74,11 +85,15 @@ local function loadOptions(self)
     local heal = 2054;
     local greaterHeal = 2060;
     local prayerOfHealing = 596;
+    local mindBlast = 8092;
 
     local surgeOfLightBuff = self.IsCata() and 88688 or 33151;
     local surgeOfLightTalent = self.IsCata() and 88687 or 33150;
     local surgeOfLightSoDBuff = 431666;
     local surgeOfLightSoDRune = 431664;
+
+    local mindSpikeSoDBuff = 431655;
+    local mindSpikeSoDRune = 431662;
 
     local serendipityBuff3 = 63734;
     local serendipityTalent = 63730;
@@ -109,6 +124,8 @@ local function loadOptions(self)
         self:AddOverlayOption(surgeOfLightSoDRune, surgeOfLightSoDBuff);
         self:AddOverlayOption(serendipitySoDBuff, serendipitySoDBuff, 0, oneOrTwoStacks, nil, 2); -- setup any stacks, test with 2 stacks
         self:AddOverlayOption(serendipitySoDBuff, serendipitySoDBuff, 3); -- setup 3 stacks
+        self:AddOverlayOption(mindSpikeSoDRune, mindSpikeSoDBuff, 0, oneOrTwoStacks, nil, 2); -- setup any stacks, test with 2 stacks
+        self:AddOverlayOption(mindSpikeSoDRune, mindSpikeSoDBuff, 3); -- setup 3 stacks
 
         self:AddGlowingOption(surgeOfLightSoDRune, surgeOfLightSoDBuff, smite);
         self:AddGlowingOption(surgeOfLightSoDRune, surgeOfLightSoDBuff, flashHeal);
@@ -116,6 +133,7 @@ local function loadOptions(self)
         self:AddGlowingOption(serendipitySoDBuff, serendipitySoDBuff, heal, threeStacks);
         self:AddGlowingOption(serendipitySoDBuff, serendipitySoDBuff, greaterHeal, threeStacks);
         self:AddGlowingOption(serendipitySoDBuff, serendipitySoDBuff, prayerOfHealing, threeStacks);
+        self:AddGlowingOption(mindSpikeSoDRune, mindSpikeSoDBuff, mindBlast, threeStacks);
     end
 end
 

--- a/classes/priest.lua
+++ b/classes/priest.lua
@@ -1,7 +1,7 @@
 local AddonName, SAO = ...
 
 local function registerClass(self)
-    if not self.IsEra() then
+    if not self.IsEra() then -- TBC/Wrath/Cata
         local smite = GetSpellInfo(585);
         local flashHeal = GetSpellInfo(2061);
 
@@ -12,22 +12,33 @@ local function registerClass(self)
 
         -- Add option links during registerClass(), not during loadOptions() which would be loaded only when the options panel is opened
         -- Add option links before RegisterAura() calls, so that options they are used by initial triggers, if any
-        self:AddOverlayLink(serendipityBuff3, serendipityBuff1);
-        self:AddOverlayLink(serendipityBuff3, serendipityBuff2);
-        self:AddGlowingLink(serendipityBuff3, serendipityBuff1);
-        self:AddGlowingLink(serendipityBuff3, serendipityBuff2);
+        if self.IsWrath() then
+            self:AddOverlayLink(serendipityBuff3, serendipityBuff1);
+            self:AddOverlayLink(serendipityBuff3, serendipityBuff2);
+            self:AddGlowingLink(serendipityBuff3, serendipityBuff1);
+            self:AddGlowingLink(serendipityBuff3, serendipityBuff2);
+        end
 
         -- Surge of Light
-        self:RegisterAura("surge_of_light", 0, 33151, "surge_of_light", "Left + Right (Flipped)", 1, 255, 255, 255, true, { smite, flashHeal });
+        local surgeOfLightBuff = self.IsCata() and 88688 or 33151;
+        if self.IsTBC() then
+            self:RegisterAura("surge_of_light", 0, surgeOfLightBuff, "surge_of_light", "Left + Right (Flipped)", 1, 255, 255, 255, true, { smite });
+        elseif self.IsWrath() then
+            self:RegisterAura("surge_of_light", 0, surgeOfLightBuff, "surge_of_light", "Left + Right (Flipped)", 1, 255, 255, 255, true, { smite, flashHeal });
+        elseif self.IsCata() then
+            self:RegisterAura("surge_of_light", 0, surgeOfLightBuff, "surge_of_light", "Left + Right (Flipped)", 1, 255, 255, 255, true, { flashHeal });
+        end
 
-        for talentPoints=1,3 do
-            local auraName = ({ "serendipity_low", "serendipity_medium", "serendipity_high" })[talentPoints];
-            local auraBuff = ({ serendipityBuff1, serendipityBuff2, serendipityBuff3 })[talentPoints];
-            for nbStacks=1,3 do
-                local scale = 0.4 + 0.2 * nbStacks; -- 60%, 80%, 100%
-                local pulse = nbStacks == 3;
-                local glowIDs = nbStacks == 3 and ghAndPoh or nil;
-                self:RegisterAura(auraName, nbStacks, auraBuff, "serendipity", "Top", scale, 255, 255, 255, pulse, glowIDs);
+        if self.IsTBC() or self.IsWrath() then
+            for talentPoints=1,3 do
+                local auraName = ({ "serendipity_low", "serendipity_medium", "serendipity_high" })[talentPoints];
+                local auraBuff = ({ serendipityBuff1, serendipityBuff2, serendipityBuff3 })[talentPoints];
+                for nbStacks=1,3 do
+                    local scale = 0.4 + 0.2 * nbStacks; -- 60%, 80%, 100%
+                    local pulse = nbStacks == 3;
+                    local glowIDs = nbStacks == 3 and ghAndPoh or nil;
+                    self:RegisterAura(auraName, nbStacks, auraBuff, "serendipity", "Top", scale, 255, 255, 255, pulse, glowIDs);
+                end
             end
         end
 
@@ -64,8 +75,8 @@ local function loadOptions(self)
     local greaterHeal = 2060;
     local prayerOfHealing = 596;
 
-    local surgeOfLightBuff = 33151;
-    local surgeOfLightTalent = 33150;
+    local surgeOfLightBuff = self.IsCata() and 88688 or 33151;
+    local surgeOfLightTalent = self.IsCata() and 88687 or 33150;
     local surgeOfLightSoDBuff = 431666;
     local surgeOfLightSoDRune = 431664;
 
@@ -78,14 +89,22 @@ local function loadOptions(self)
 
     if not self.IsEra() then
         self:AddOverlayOption(surgeOfLightTalent, surgeOfLightBuff);
-        self:AddOverlayOption(serendipityTalent, serendipityBuff3, 0, oneOrTwoStacks, nil, 2); -- setup any stacks, test with 2 stacks
-        self:AddOverlayOption(serendipityTalent, serendipityBuff3, 3); -- setup 3 stacks
+        if self.Wrath() then
+            self:AddOverlayOption(serendipityTalent, serendipityBuff3, 0, oneOrTwoStacks, nil, 2); -- setup any stacks, test with 2 stacks
+            self:AddOverlayOption(serendipityTalent, serendipityBuff3, 3); -- setup 3 stacks
+        end
         self:AddSoulPreserverOverlayOption(60514); -- 60514 = Priest buff
 
-        self:AddGlowingOption(surgeOfLightTalent, surgeOfLightBuff, smite);
-        self:AddGlowingOption(surgeOfLightTalent, surgeOfLightBuff, flashHeal);
-        self:AddGlowingOption(serendipityTalent, serendipityBuff3, greaterHeal, threeStacks);
-        self:AddGlowingOption(serendipityTalent, serendipityBuff3, prayerOfHealing, threeStacks);
+        if self.TBC() or self.Wrath() then
+            self:AddGlowingOption(surgeOfLightTalent, surgeOfLightBuff, smite);
+        end
+        if self.Wrath() or self.Cata() then
+            self:AddGlowingOption(surgeOfLightTalent, surgeOfLightBuff, flashHeal);
+        end
+        if self.Wrath() then
+            self:AddGlowingOption(serendipityTalent, serendipityBuff3, greaterHeal, threeStacks);
+            self:AddGlowingOption(serendipityTalent, serendipityBuff3, prayerOfHealing, threeStacks);
+        end
     elseif self.IsSoD() then
         self:AddOverlayOption(surgeOfLightSoDRune, surgeOfLightSoDBuff);
         self:AddOverlayOption(serendipitySoDBuff, serendipitySoDBuff, 0, oneOrTwoStacks, nil, 2); -- setup any stacks, test with 2 stacks

--- a/options/defaults.lua
+++ b/options/defaults.lua
@@ -299,6 +299,10 @@ SAO.defaults = {
                 [431666] = {  -- Surge of Light (Season of Discovery)
                     [0] = true,
                 },
+                [431655] = {  -- Mind Spike (Season of Discovery)
+                    [3] = true,  -- 3 stacks
+                    [0] = false, -- any stacks but 3
+                },
             },
             glow = {
                 [33151] = { -- Surge of Light (TBC - Wrath)
@@ -322,6 +326,9 @@ SAO.defaults = {
                     [585]  = true, -- Smite
                     [2061] = true, -- Flash Heal
                 },
+                [431655] = {  -- Mind Spike (Season of Discovery)
+                    [8092] = true, -- Mind Blast
+                }
             },
         },
         ["ROGUE"] = {

--- a/options/defaults.lua
+++ b/options/defaults.lua
@@ -250,7 +250,7 @@ SAO.defaults = {
                 [59578] = { -- The Art of War (2/2) (Wrath+)
                     [0] = true,
                 },
-                [60513] = { -- Healing Trance / Soul Preserver (Wrath+)
+                [60513] = { -- Healing Trance / Soul Preserver (Wrath)
                     [0] = false,
                 },
             },
@@ -279,14 +279,14 @@ SAO.defaults = {
         },
         ["PRIEST"] = {
             alert = {
-                [33151] = {  -- Surge of Light
+                [33151] = {  -- Surge of Light (TBC - Wrath)
                     [0] = true,
                 },
-                [63734] = { -- Serendipity
+                [63734] = { -- Serendipity (Wrath)
                     [3] = true,  -- 3 stacks
                     [0] = false, -- any stacks but 3
                 },
-                [60514] = { -- Healing Trance / Soul Preserver
+                [60514] = { -- Healing Trance / Soul Preserver (Wrath)
                     [0] = false,
                 },
                 [413247]= { -- Serendipity (Season of Discovery)
@@ -298,11 +298,11 @@ SAO.defaults = {
                 },
             },
             glow = {
-                [33151] = { -- Surge of Light
+                [33151] = { -- Surge of Light (TBC - Wrath)
                     [585]  = true, -- Smite
-                    [2061] = true, -- Flash Heal
+                    [2061] = true, -- Flash Heal (does not proc for TBC)
                 },
-                [63734] = { -- Serendipity 3/3
+                [63734] = { -- Serendipity 3/3 (Wrath)
                     [2060] = true, -- Greater Heal
                     [596]  = true, -- Prayer of Healing
                 },

--- a/options/defaults.lua
+++ b/options/defaults.lua
@@ -282,6 +282,9 @@ SAO.defaults = {
                 [33151] = {  -- Surge of Light (TBC - Wrath)
                     [0] = true,
                 },
+                [88688] = {  -- Surge of Light (Cataclysm)
+                    [0] = true,
+                },
                 [63734] = { -- Serendipity (Wrath)
                     [3] = true,  -- 3 stacks
                     [0] = false, -- any stacks but 3
@@ -301,6 +304,9 @@ SAO.defaults = {
                 [33151] = { -- Surge of Light (TBC - Wrath)
                     [585]  = true, -- Smite
                     [2061] = true, -- Flash Heal (does not proc for TBC)
+                },
+                [88688] = { -- Surge of Light (Cataclysm)
+                    [2061] = true, -- Flash Heal
                 },
                 [63734] = { -- Serendipity 3/3 (Wrath)
                     [2060] = true, -- Greater Heal


### PR DESCRIPTION
Implements #222.

Also cleans Wrath and TBC conditions for Priests, and implements Surge of Light for Cataclysm.