### PR TITLE
fix: show master marksman proc overlay

### DIFF
--- a/classes/hunter.lua
+++ b/classes/hunter.lua
@@ -64,7 +64,7 @@ local function useMasterMarksman()
         "aura",
         {
             talent = masterMarksmanTalent,
-            overlay = { stacks = 5, texture = "master_marksman", position = "Top" },
+            overlay = { stacks = 1, texture = "master_marksman", position = "Top" },
             button = aimedShotBang,
         }
     );


### PR DESCRIPTION
overlay config table was using the wrong number of aura stacks - the proc aura doesn't have stacks

after reaching 5 stacks of ["Ready, Set, Aim..."](https://www.wowhead.com/cata/spell=82925/ready-set-aim) the aura is removed and replaced with a single stack of ["Fire!"](https://www.wowhead.com/cata/spell=82926/fire)