### PR TITLE
Cataclysm Mage follow-up

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
         "ceil",
         "hooksecurefunc",
         "strfind",
+        "strlenutf8",
         "strlower",
         "strupper",
         "tDeleteItem",

--- a/SpellActivationOverlay.lua
+++ b/SpellActivationOverlay.lua
@@ -175,14 +175,14 @@ function SpellActivationOverlay_OnEvent(self, event, ...)
 		-- end
 	end
 	if ( not self.disableDimOutOfCombat ) then
-		if ( event == "PLAYER_REGEN_DISABLED" ) then
+		if ( event == "PLAYER_REGEN_DISABLED" and self.inPseudoCombat ~= true ) then
 			self.combatAnimOut:Stop();	--In case we're in the process of animating this out.
 			self.combatAnimIn:Play();
 			for _, overlay in ipairs(self.combatOnlyOverlays) do
 				overlay.combat.animOut:Stop();
 				SpellActivationOverlayFrame_PlayCombatAnimIn(overlay.combat.animIn);
 			end
-		elseif ( event == "PLAYER_REGEN_ENABLED" ) then
+		elseif ( event == "PLAYER_REGEN_ENABLED" and self.inPseudoCombat ~= false ) then
 			self.combatAnimIn:Stop();	--In case we're in the process of animating this out.
 			self.combatAnimOut:Play();
 			for _, overlay in ipairs(self.combatOnlyOverlays) do
@@ -706,6 +706,22 @@ function SpellActivationOverlayFrame_OnFadeInFinished(anim)
 			end
 		end
 	end
+end
+
+function SpellActivationOverlayFrame_OnEnterCombat(anim)
+	SAO:Trace(Module, "SpellActivationOverlayFrame_OnEnterCombat "..tostring(anim));
+	-- Combat has started, or pseudo-started
+	-- A pseudo-start happens when a proc was just triggered and the effect is visible shortly
+	-- In this case, the player may or may not be in combat, but overlays will be visible as if in combat
+	local frame = anim:GetParent();
+	frame.inPseudoCombat = true;
+end
+
+function SpellActivationOverlayFrame_OnLeaveCombat(anim)
+	SAO:Trace(Module, "SpellActivationOverlayFrame_OnLeaveCombat "..tostring(anim));
+	-- Combat has finished, or pseudo-finished (see SpellActivationOverlayFrame_OnEnterCombat)
+	local frame = anim:GetParent();
+	frame.inPseudoCombat = false;
 end
 
 function SpellActivationOverlayFrame_SetForceAlpha1(enabled)

--- a/SpellActivationOverlay.lua
+++ b/SpellActivationOverlay.lua
@@ -544,6 +544,7 @@ function SpellActivationOverlayTexture_TerminateOverlay(overlay)
 	overlay:Hide();
 	tDeleteItem(overlayParent.overlaysInUse[overlay.spellID], overlay);
 	tinsert(overlayParent.unusedOverlays, overlay);
+	tDeleteItem(overlayParent.combatOnlyOverlays, overlay);
 end
 
 function SpellActivationOverlayFrame_OnTimeoutFinished(anim)

--- a/SpellActivationOverlay.lua
+++ b/SpellActivationOverlay.lua
@@ -392,6 +392,13 @@ function SpellActivationOverlay_ShowOverlay(self, spellID, texturePath, position
 	end
 end
 
+function SpellActivationOverlay_DumpCombatOnlyOverlays()
+	SAO:Info(Module, "Listing combat-only overlays ("..#SAO.Frame.combatOnlyOverlays.." item"..(#SAO.Frame.combatOnlyOverlays == 1 and "" or "s")..")");
+	for i, overlay in pairs(SAO.Frame.combatOnlyOverlays) do
+		SAO:Info(Module, "combat-only-overlay["..i.."] location == "..overlay.position..", spell ID = "..overlay.spellID.." "..(GetSpellInfo(overlay.spellID) or ""));
+	end
+end
+
 function SpellActivationOverlay_GetOverlay(self, spellID, position)
 	local overlayList = self.overlaysInUse[spellID];
 	local overlay;

--- a/SpellActivationOverlay.lua
+++ b/SpellActivationOverlay.lua
@@ -14,6 +14,7 @@ local useTimer = true;
 local useSound = false;
 
 function SpellActivationOverlay_OnLoad(self)
+	SAO_Frame = self;
 	SAO.Frame = self;
 	SAO.ShowAllOverlays = SpellActivationOverlay_ShowAllOverlays;
 	SAO.HideOverlays = SpellActivationOverlay_HideOverlays;

--- a/SpellActivationOverlay.xml
+++ b/SpellActivationOverlay.xml
@@ -118,6 +118,7 @@
 						<Alpha order="1" duration="0.1" fromAlpha="0.5" toAlpha="1"/>
 						<Alpha order="2" duration="4.9" fromAlpha="1" toAlpha="1"/>
 						<Scripts>
+							<OnPlay function="SpellActivationOverlayFrame_OnEnterCombat"/>
 							<OnFinished function="SpellActivationOverlayFrame_OnFadeInFinished"/>
 						</Scripts>
 					</AnimationGroup>
@@ -125,6 +126,9 @@
 						<Alpha order="1" duration="0.2"  fromAlpha="1"   toAlpha="0.5"/>
 						<Alpha order="2" duration="27.8" fromAlpha="0.5" toAlpha="0.5"/>
 						<Alpha order="3" duration="2"    fromAlpha="0.5" toAlpha="0"/>
+						<Scripts>
+							<OnPlay function="SpellActivationOverlayFrame_OnLeaveCombat"/>
+						</Scripts>
 					</AnimationGroup>
 				</Animations>
 				<Scripts>

--- a/SpellActivationOverlay.xml
+++ b/SpellActivationOverlay.xml
@@ -4,18 +4,18 @@
 	<Frame name="SpellActivationOverlayTemplate" virtual="true">
 		<Animations>
 			<AnimationGroup name="$parentAnimIn" parentKey="animIn">
-				<Alpha fromAlpha="0" toAlpha="1" duration="0.2"/>
-				<Scripts>
-					<OnPlay function="SpellActivationOverlayTexture_OnFadeInPlay"/>
-					<OnFinished function="SpellActivationOverlayTexture_OnFadeInFinished"/>
-				</Scripts>
-				<Animation duration="0.1">
-					<!-- Dummy animation, whose goal in to plug in a function to circumvent a bug with pulse animations -->
+				<Alpha fromAlpha="0" toAlpha="0.5" duration="0.1" order="1" parentKey="alpha1">
+					<!-- Split alpha animation in 2 steps , whose goal in to plug in a function to circumvent a bug with pulse animations -->
 					<!-- If this script is not called slightly early (0.1 secs in, instead of 0.2 sec), starting the pulse may cause a weird flash -->
 					<Scripts>
 						<OnFinished function="SpellActivationOverlayTexture_PreStartPulse"/>
 					</Scripts>
-				</Animation>
+				</Alpha>
+				<Alpha fromAlpha="0.5" toAlpha="1" duration="0.1" order="2" parentKey="alpha2"/>
+				<Scripts>
+					<OnPlay function="SpellActivationOverlayTexture_OnFadeInPlay"/>
+					<OnFinished function="SpellActivationOverlayTexture_OnFadeInFinished"/>
+				</Scripts>
 			</AnimationGroup>
 			<AnimationGroup name="$parentAnimOut" parentKey="animOut">
 				<Alpha fromAlpha="1" toAlpha="0" duration="0.1">

--- a/SpellActivationOverlay.xml
+++ b/SpellActivationOverlay.xml
@@ -9,13 +9,13 @@
 					<OnPlay function="SpellActivationOverlayTexture_OnFadeInPlay"/>
 					<OnFinished function="SpellActivationOverlayTexture_OnFadeInFinished"/>
 				</Scripts>
-				<Translation offsetX="0" offsetY="0" duration="0.1">
+				<Animation duration="0.1">
 					<!-- Dummy animation, whose goal in to plug in a function to circumvent a bug with pulse animations -->
 					<!-- If this script is not called slightly early (0.1 secs in, instead of 0.2 sec), starting the pulse may cause a weird flash -->
 					<Scripts>
 						<OnFinished function="SpellActivationOverlayTexture_PreStartPulse"/>
 					</Scripts>
-				</Translation>
+				</Animation>
 			</AnimationGroup>
 			<AnimationGroup name="$parentAnimOut" parentKey="animOut">
 				<Alpha fromAlpha="1" toAlpha="0" duration="0.1">

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 Bug Fixes
 - Spell Alerts should no longer display a visual timer shorter than intended
+- Glowing button settings are more visible when there are more than 12 buttons
 - Mage's Frozen debuff had incorrect texture orientation (Cataclysm)
 - Mage's Improved Cone of Cold did not trigger Frozen debuff (Cataclysm)
 - Mage's Ring of Frost did not trigger Frozen debuff (Cataclysm)

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ Bug Fixes
 - Mage's Frozen debuff had incorrect texture orientation (Cataclysm)
 - Mage's Improved Cone of Cold did not trigger Frozen debuff (Cataclysm)
 - Mage's Ring of Frost did not trigger Frozen debuff (Cataclysm)
+- Mage's Arcane Potency at 1 stack did not fade out after combat (Cataclysm)
 - Warlock's Backdraft was not triggered correctly (Cataclysm)
 
 #### v1.4.2 (2024-05-11)

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 #### v1.4.3 (2024-05-xx)
 
 Bug Fixes
+- Spell Alerts should no longer display a visual timer shorter than intended
 - Mage's Frozen debuff had incorrect texture orientation (Cataclysm)
 - Mage's Improved Cone of Cold did not trigger Frozen debuff (Cataclysm)
 - Mage's Ring of Frost did not trigger Frozen debuff (Cataclysm)

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 ## SpellActivationOverlay Changelog
 
+#### v1.4.3 (2024-05-xx)
+
+Bug Fixes
+- Mage's Ring of Frost did not trigger Frozen debuff (Cataclysm)
+
 #### v1.4.2 (2024-05-11)
 
 Bug Fixes

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 Bug Fixes
 - Spell Alerts should no longer display a visual timer shorter than intended
+- Combat-only Spell Alerts should no longer flicker when entering combat
 - Glowing button settings are more visible when there are more than 12 buttons
 - Mage's Frozen debuff had incorrect texture orientation (Cataclysm)
 - Mage's Improved Cone of Cold did not trigger Frozen debuff (Cataclysm)

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ Bug Fixes
 - Mage's Frozen debuff had incorrect texture orientation (Cataclysm)
 - Mage's Improved Cone of Cold did not trigger Frozen debuff (Cataclysm)
 - Mage's Ring of Frost did not trigger Frozen debuff (Cataclysm)
+- Warlock's Backdraft was not triggered correctly (Cataclysm)
 
 #### v1.4.2 (2024-05-11)
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 #### v1.4.3 (2024-05-xx)
 
 Bug Fixes
+- Mage's Frozen debuff had incorrect texture orientation (Cataclysm)
 - Mage's Improved Cone of Cold did not trigger Frozen debuff (Cataclysm)
 - Mage's Ring of Frost did not trigger Frozen debuff (Cataclysm)
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 #### v1.4.3 (2024-05-xx)
 
 Bug Fixes
+- Mage's Improved Cone of Cold did not trigger Frozen debuff (Cataclysm)
 - Mage's Ring of Frost did not trigger Frozen debuff (Cataclysm)
 
 #### v1.4.2 (2024-05-11)

--- a/classes/mage.lua
+++ b/classes/mage.lua
@@ -246,6 +246,7 @@ local FrozenHandler = {
     deep_freeze = { 44572 }, -- Deep Freeze is both a debuff for 'Frozen' Spell Alert and its own Glowing Button
     deep_freeze_sod = { 428739 }, -- Season of Discovery
     hungering_cold = { 49203 }, -- from Death Knights
+    ring_of_frost = { 82691 },
 
     freezeID = 5276, -- Not really a 'Frozen' spell ID, but the name should help players identify the intent
     freezeTalent = 5276,
@@ -278,6 +279,7 @@ local FrozenHandler = {
         self:addSpellIDCandidates(self.deep_freeze);
         self:addSpellIDCandidates(self.deep_freeze_sod);
         self:addSpellIDCandidates(self.hungering_cold);
+        self:addSpellIDCandidates(self.ring_of_frost);
 
         self.freezable = self:isTargetFreezable();
         if (self.freezable and self:isTargetFrozen()) then

--- a/classes/mage.lua
+++ b/classes/mage.lua
@@ -726,7 +726,7 @@ local function loadOptions(self)
     elseif self.IsCata() then
         self:AddOverlayOption(fingersOfFrostTalent, fingersOfFrostBuffCata, 0, nil, nil, 2); -- setup any stacks, test with 2 stacks
     end
-    self:AddOverlayOption(FrozenHandler.freezeTalent, FrozenHandler.freezeID, 0, nil, nil, nil, FrozenHandler.fakeSpellID);
+    self:AddOverlayOption(FrozenHandler.freezeTalent, FrozenHandler.freezeID, 0, self:translateDebuff(), nil, nil, FrozenHandler.fakeSpellID);
     if self.IsSoD() then
         self:AddOverlayOption(brainFreezeSoDRune, brainFreezeSoDBuff);
     else

--- a/classes/mage.lua
+++ b/classes/mage.lua
@@ -246,6 +246,7 @@ local FrozenHandler = {
     deep_freeze = { 44572 }, -- Deep Freeze is both a debuff for 'Frozen' Spell Alert and its own Glowing Button
     deep_freeze_sod = { 428739 }, -- Season of Discovery
     hungering_cold = { 49203 }, -- from Death Knights
+    improved_cone_of_cold = { 83301, 83302 },
     ring_of_frost = { 82691 },
 
     freezeID = 5276, -- Not really a 'Frozen' spell ID, but the name should help players identify the intent
@@ -279,6 +280,7 @@ local FrozenHandler = {
         self:addSpellIDCandidates(self.deep_freeze);
         self:addSpellIDCandidates(self.deep_freeze_sod);
         self:addSpellIDCandidates(self.hungering_cold);
+        self:addSpellIDCandidates(self.improved_cone_of_cold);
         self:addSpellIDCandidates(self.ring_of_frost);
 
         self.freezable = self:isTargetFreezable();

--- a/classes/mage.lua
+++ b/classes/mage.lua
@@ -673,27 +673,7 @@ local function loadOptions(self)
     local deepFreeze = FrozenHandler.deep_freeze[1];
     local deepFreezeSoD = FrozenHandler.deep_freeze_sod[1];
 
-    local heatingUpDetails;
-    local locale = GetLocale();
-    if (locale == "deDE") then
-        heatingUpDetails = "Aufwärmen";
-    elseif (locale == "frFR") then
-        heatingUpDetails = "Réchauffement";
-    elseif (locale == "esES" or locale == "esMX") then
-        heatingUpDetails = "Calentamiento"; -- Always use esES because esMX isn't on Wowhead
-    elseif (locale == "ruRU") then
-        heatingUpDetails = "Разогрев";
-    elseif (locale == "itIT") then
-        heatingUpDetails = "Riscaldamento";
-    elseif (locale == "ptBR") then
-        heatingUpDetails = "Aquecendo";
-    elseif (locale == "koKR") then
-        heatingUpDetails = "열기";
-    elseif (locale == "zhCN" or locale == "zhTW") then
-        heatingUpDetails = "热力迸发"; -- Always use zhCN because zhTW isn't on Wowhead
-    else
-        heatingUpDetails = "Heating Up";
-    end
+    local heatingUpDetails = self:translateHeatingUp();
 
     -- local spellName, _, spellIcon = GetSpellInfo(pyroblast);
     -- local hotStreakDetails = string.format(LFG_READY_CHECK_PLAYER_IS_READY, "|T"..spellIcon..":0|t "..spellName):gsub("%.", "");

--- a/classes/mage.lua
+++ b/classes/mage.lua
@@ -254,7 +254,8 @@ local FrozenHandler = {
     fakeSpellID = 5276+1000000, -- For option testing
 
     saoTexture = "frozen_fingers",
-    saoScaleFactor = (SAO.IsEra() or SAO.IsTBC()) and 1 or 0.75, -- Scaling down on Wrath because of conflict
+    saoPosition = SAO.IsCata() and "Top" or "Top (CW)"; -- Re-orient in Cataclysm because former effect had different orientation
+    saoScaleFactor = (SAO.IsEra() or SAO.IsTBC()) and 1 or 0.75, -- Scaling down on Wrath and Cataclysm because of conflict
 
     -- Constants that will be initialized at init()
     allSpellIDs = {},
@@ -411,7 +412,7 @@ local FrozenHandler = {
         local hasSAO = not saoOption or type(saoOption[0]) == "nil" or saoOption[0];
         if (hasSAO) then
             local endTime = self:getEndTime();
-            SAO:ActivateOverlay(0, self.freezeID, SAO.TexName[self.saoTexture], "Top (CW)", self.saoScaleFactor, 255, 255, 255, false, nil, endTime);
+            SAO:ActivateOverlay(0, self.freezeID, SAO.TexName[self.saoTexture], self.saoPosition, self.saoScaleFactor, 255, 255, 255, false, nil, endTime);
         end
 
         -- GABs

--- a/components/aura.lua
+++ b/components/aura.lua
@@ -119,7 +119,7 @@ function SAO:ChangeAuraCount(spellID, oldCount, newCount, auras)
     self:RemoveGlow(spellID);
     self:MarkAura(spellID, newCount); -- Call MarkAura after DeactivateOverlay, because DeactivateOverlay may reset its aura marker
     for _, aura in ipairs(auras) do
-        local texture, positions, scale, r, g, b, autoPulse, _, combatOnly = select(4,unpack(aura));
+        local texture, positions, scale, r, g, b, autoPulse, _, _, combatOnly = select(4,unpack(aura));
         local forcePulsePlay = autoPulse;
         self:ActivateOverlay(newCount, spellID, texture, positions, scale, r, g, b, autoPulse, forcePulsePlay, nil, combatOnly);
         self:AddGlow(spellID, select(11,unpack(aura)));

--- a/components/events.lua
+++ b/components/events.lua
@@ -80,12 +80,7 @@ function SAO.SPELL_AURA(self, ...)
         (auras[count])
     ) then
         -- Activate aura
-        self:Debug(Module, "Activating aura of "..spellID.." "..(GetSpellInfo(spellID) or ""));
-        for _, aura in ipairs(auras[count]) do
-            self:MarkAura(spellID, count);
-            self:ActivateOverlay(count, select(3,unpack(aura)));
-            self:AddGlow(spellID, select(11,unpack(aura)));
-        end
+        self:DisplayAllAuras(spellID, count, auras[count]);
     elseif (
         -- Aura is already visible
         (isDisplayed)
@@ -97,8 +92,7 @@ function SAO.SPELL_AURA(self, ...)
         (auras[count])
     ) then
         -- Reactivate aura timer
-        self:Debug(Module, "Refreshing aura of "..spellID.." "..(GetSpellInfo(spellID) or ""));
-        self:RefreshOverlayTimer(spellID);
+        self:RefreshAura(spellID);
     elseif (
         -- Aura is already visible
         (isDisplayed)
@@ -116,16 +110,7 @@ function SAO.SPELL_AURA(self, ...)
         (auras[count])
     ) then
         -- Deactivate old aura and activate the new one
-        self:Debug(Module, "Changing number of stacks from "..tostring(displayedCount).." to "..count.." for aura "..spellID.." "..(GetSpellInfo(spellID) or ""));
-        self:DeactivateOverlay(spellID);
-        self:RemoveGlow(spellID);
-        self:MarkAura(spellID, count); -- Call MarkAura after DeactivateOverlay, because DeactivateOverlay may reset its aura marker
-        for _, aura in ipairs(auras[count]) do
-            local texture, positions, scale, r, g, b, autoPulse, _, combatOnly = select(4,unpack(aura));
-            local forcePulsePlay = autoPulse;
-            self:ActivateOverlay(count, spellID, texture, positions, scale, r, g, b, autoPulse, forcePulsePlay, nil, combatOnly);
-            self:AddGlow(spellID, select(11,unpack(aura)));
-        end
+        self:ChangeAuraCount(spellID, displayedCount, count, auras[count]);
     elseif (
         -- Aura is already visible
         (isDisplayed)
@@ -141,10 +126,7 @@ function SAO.SPELL_AURA(self, ...)
         (auraRemovedLast or ((auraAppliedDose or auraRemovedDose) and displayedCount ~= count and not auras[count]))
     ) then
         -- Aura just disappeared or is not supported for this number of stacks
-        self:Debug(Module, "Removing aura of "..spellID.." "..(GetSpellInfo(spellID) or ""));
-        -- self:UnmarkAura(spellID); -- No need to unmark explicitly, because DeactivateOverlay does it automatically
-        self:DeactivateOverlay(spellID);
-        self:RemoveGlow(spellID);
+        self:UndisplayAura(spellID);
     end
 end
 

--- a/components/events.lua
+++ b/components/events.lua
@@ -9,15 +9,32 @@ local UnitGUID = UnitGUID
 -- Events starting with SPELL_AURA e.g., SPELL_AURA_APPLIED
 -- This should be invoked only if the buff is done on the player i.e., UnitGUID("player") == destGUID
 function SAO.SPELL_AURA(self, ...)
-    local timestamp, event, _, sourceGUID, sourceName, sourceFlags, sourceRaidFlags, destGUID, destName, destFlags, destRaidFlags = CombatLogGetCurrentEventInfo();
-    local spellID, spellName, spellSchool, auraType, amount = select(12, CombatLogGetCurrentEventInfo());
-    local auraApplied = event:sub(0,18) == "SPELL_AURA_APPLIED";
-    local auraRemoved = event:sub(0,18) == "SPELL_AURA_REMOVED";
-    local auraRefresh = event:sub(0,18) == "SPELL_AURA_REFRESH";
-    if not auraApplied and not auraRemoved and not auraRefresh then
+    local _, event, _, _, _, _, _, _, _, _, _, spellID, spellName = CombatLogGetCurrentEventInfo();
+
+    --[[ Aura event chart
+
+    For un-stackable auras:
+    - "SPELL_AURA_APPLIED" = buff is being applied now
+    - "SPELL_AURA_REMOVED" = buff is being removed now
+
+    For stackable auras:
+    - "SPELL_AURA_APPLIED" = first stack applied
+    - "SPELL_AURA_APPLIED_DOSE" = second stack applied or beyond
+    - "SPELL_AURA_REMOVED_DOSE" = removed a stack, but there is at least one stack left
+    - "SPELL_AURA_REMOVED" = removed last remaining stack
+
+    For any aura:
+    - "SPELL_AURA_REFRESH" = buff is refreshed, usually the remaining time is reset to its max duration
+    ]]
+    local auraApplied = event:sub(0,18) == "SPELL_AURA_APPLIED"; -- includes "SPELL_AURA_APPLIED" and "SPELL_AURA_APPLIED_DOSE"
+    local auraRemovedLast = event == "SPELL_AURA_REMOVED";
+    local auraRemovedDose = event == "SPELL_AURA_REMOVED_DOSE";
+    local auraRefresh = event == "SPELL_AURA_REFRESH";
+    if not auraApplied and not auraRemovedLast and not auraRemovedDose and not auraRefresh then
         return; -- Not an event we're interested in
     end
 
+    -- Use the game's aura from CLEU to find its corresponding aura item in SAO, if any
     local auras;
     if not self.IsEra() then
         auras = self.RegisteredAurasBySpellID[spellID];
@@ -33,31 +50,31 @@ function SAO.SPELL_AURA(self, ...)
             end
         end
     end
-
     if not auras then
-        -- Not tracking this spell
+        -- This spell is not tracked by SAO
         return;
     end
 
-    local auraAppliedFirst = event == "SPELL_AURA_APPLIED";      -- For stackable auras: first stack applied; for unstackable auras: buff applied
-    local auraAppliedDose  = event == "SPELL_AURA_APPLIED_DOSE"; -- For stackable auras: second stack applied or beyond; for unstackable auras: N/A
-    local auraRemovedLast  = event == "SPELL_AURA_REMOVED";      -- For stackable auras: removed last remaining stack; for unstackable auras: buff removed
-    local auraRemovedDose  = event == "SPELL_AURA_REMOVED_DOSE"; -- For stackable auras: removed a stack, but there is at least one stack left; for unstackable auras: N/A
-
-    local count = 0;
-    if not auras[0] then
+    local count = 0; -- Number of stacks of the aura, unless the aura is count-agnostic (see below)
+    local countAgnostic; -- Flag to tell that we don't care what is the exact stack count
+    if auras[0] then
+        -- An aura which defined stacks == 0 means the aura is count-agnostic
+        -- What matters is whether or not the buff is found, independently of its number of stacks
+        -- Please note, count-agnostic auras may or may not be stackable, they just don't care about the number of stacks, if any
+        countAgnostic = true;
+    else
         -- If there is no aura with stacks == 0, this must mean that this aura is stackable
+        -- Unlike count-agnostic auras, non-count-agnostic auras are *always* stackable
+        countAgnostic = false;
         -- To handle stackable auras, we must find the aura (ugh!) to get its number of stacks
         -- In an ideal world, we'd use a stack count from the combat log which, unfortunately, is unavailable
-        count = select(3, self:FindPlayerAuraByID(spellID)) or 0;
-        -- Please note, the opposite is not necessarily true:
-        -- if an aura is defined with stacks == 0, it does not guarantee that the aura is not stackable
-        -- it means that the aura is count-agnostic, meaning we don't care how many count it has
-        -- in other words, the only thing that matters is whether or not the buff is found, independently of its number of stacks
+        if event ~= "SPELL_AURA_REMOVED" then -- No need to find aura with complete removal: the buff is not there anymore
+            count = select(3, self:FindPlayerAuraByID(spellID)) or 0;
+        end
     end
 
     --[[ Check if the spell is currently displayed, and if yes, with which count
-    Returned count will always be zero if tracking a count-agnostic aura (because the above if/then/else statement will be skipped)
+    Reminder: returned count will always be zero if tracking a count-agnostic aura
     Possible values:
     - 1 or more, if the aura is displayed and it is a stackable aura, in which case the value indicates the number of stacks
     - 0, if the aura is displayed and either the aura is not stackable or the effect is count-agnostic
@@ -65,42 +82,70 @@ function SAO.SPELL_AURA(self, ...)
     ]]
     local displayedCount = self:GetAuraMarker(spellID);
     local isDisplayed = displayedCount ~= nil;
-    if (
-        -- Aura not visible yet
-        (not isDisplayed)
-    and
+
+    -- Handle unique case first: aura refresh
+    if (auraRefresh) then
+        if (
+            -- Aura is already visible
+            (isDisplayed)
+        and
+            -- The number of stacks is supported
+            (auras[count])
+        ) then
+            -- Reactivate aura timer
+            self:RefreshAura(spellID);
+        end
+
+        -- Can return now, because SPELL_AURA_REFRESH is used only to refresh timer
+        return;
+    end
+
+    -- Now, we are in a situation where either we got a buff (SPELL_AURA_APPLIED*) or lost it (SPELL_AURA_REMOVED*)
+
+    -- Check if we should activate the aura effect
+    if (not isDisplayed) then
+        if (
         --[[ Aura is enabled, either because:
-        - it was added (auraAppliedFirst)
-        - or was upgraded (auraAppliedDose)
-        - or was downgraded but still visible (auraRemovedDose)
+        - it was added now (SPELL_AURA_APPLIED)
+        - or was upgraded (SPELL_AURA_APPLIED_DOSE)
+        - or was downgraded but still visible (SPELL_AURA_REMOVED_DOSE)
         ]]
-        (auraApplied or auraRemovedDose)
-    and
-        -- The number of stacks is supported
-        (auras[count])
-    ) then
-        -- Activate aura
-        self:DisplayAllAuras(spellID, count, auras[count]);
-    elseif (
-        -- Aura is already visible
-        (isDisplayed)
-    and
-        -- Aura is re-applied
-        (auraRefresh)
-    and
-        -- The number of stacks is supported
-        (auras[count])
-    ) then
-        -- Reactivate aura timer
-        self:RefreshAura(spellID);
-    elseif (
-        -- Aura is already visible
-        (isDisplayed)
-    and
-        --[[ Its number of stacks changed
-        Note: if the aura is count-agnostic, this test will always return false, which suits us
-        When an aura is count-agnostic, we don't care when an aura goes from count A to count B because, by definition, the exact count does not matter
-        ]]
+            (auraApplied or auraRemovedDose)
+        and
+            -- The number of stacks is supported
+            (auras[count])
+        ) then
+            -- Activate aura
+            self:DisplayAllAuras(spellID, count, auras[count]);
+        end
+
+        -- Can return now, because a non-displayed is either displayed now, or nothing can be done with it
+        return;
+    end
+
+    --[[ At this point:
+    - isDisplayed == true, meaning the aura is currently displayed on screen
+    - displayedCount equals to either:
+      - 0 for count-agnostic auras
+      - otherwise, the number of currently displayed stacks
+    ]]
+
+    if (countAgnostic) then
+        if (
+            -- The aura is completely removed (SPELL_AURA_REMOVED)
+            (auraRemovedLast)
+        ) then
+            -- Aura just disappeared completely
+            -- For count-agnostic aura, it does not matter which count it came from, if the aura is missing: hide it
+            self:UndisplayAura(spellID);
+        end
+
+        -- Can return now: count-agnostic auras of displayed auras are either un-displayed, or nothing can be done with it
+        return;
+    end
+
+    if (
+        -- Number of stacks changed
         (displayedCount ~= count)
     and
         -- The new stack count allows it to be visible
@@ -111,19 +156,15 @@ function SAO.SPELL_AURA(self, ...)
     ) then
         -- Deactivate old aura and activate the new one
         self:ChangeAuraCount(spellID, displayedCount, count, auras[count]);
-    elseif (
-        -- Aura is already visible
-        (isDisplayed)
-    and
+        return;
+    end
+
+    if (
         --[[ The aura should not be visible, either because:
-        - the aura is completely removed (auraRemovedLast)
+        - the aura is completely removed (SPELL_AURA_REMOVED)
         - or the aura has changed stacks to an unsupported stack count
-        Note: a count-agnostic aura will have its count == 0, in which case the 'stack change test' will always return false, which suits us
-        A count-agnostic aura only cares whether the buff is active or not, the exact count does not matter
-        Because of this, it doesn't make any sense to e.g. "remove the aura because the new number of stacks is unsupported"
-        If you wonder when it is possible to deactivate an aura-agnostic effect, the answer is simple: when it is completely removed (auraRemovedLast)
         ]]
-        (auraRemovedLast or ((auraAppliedDose or auraRemovedDose) and displayedCount ~= count and not auras[count]))
+        (auraRemovedLast or ((auraApplied or auraRemovedDose) and displayedCount ~= count and not auras[count]))
     ) then
         -- Aura just disappeared or is not supported for this number of stacks
         self:UndisplayAura(spellID);

--- a/components/events.lua
+++ b/components/events.lua
@@ -14,6 +14,9 @@ function SAO.SPELL_AURA(self, ...)
     local auraApplied = event:sub(0,18) == "SPELL_AURA_APPLIED";
     local auraRemoved = event:sub(0,18) == "SPELL_AURA_REMOVED";
     local auraRefresh = event:sub(0,18) == "SPELL_AURA_REFRESH";
+    if not auraApplied and not auraRemoved and not auraRefresh then
+        return; -- Not an event we're interested in
+    end
 
     local auras;
     if not self.IsEra() then
@@ -31,81 +34,117 @@ function SAO.SPELL_AURA(self, ...)
         end
     end
 
-    if auras and (auraApplied or auraRemoved or auraRefresh) then
-        local count = 0;
-        if (not auras[0]) then
-            -- If there is no aura with stacks == 0, this must mean that this aura is stackable
-            -- To handle stackable auras, we must find the aura (ugh!) to get its number of stacks
-            -- In an ideal world, we'd use the 'amount' which, unfortunately, is unreliable
-            count = select(3, self:FindPlayerAuraByID(spellID));
-        end
+    if not auras then
+        -- Not tracking this spell
+        return;
+    end
 
-        local currentlyActiveOverlay = self:GetActiveOverlay(spellID);
-        if (
-            -- Aura not visible yet
-            (not currentlyActiveOverlay)
-        and
-            -- Aura is there, either because it was added or upgraded or downgraded but still visible
-            (auraApplied or (auraRemoved and count and count > 0))
-        and
-            -- The number of stacks is supported
-            (auras[count])
-        ) then
-            -- Activate aura
-            self:Debug(Module, "Activating aura of "..spellID.." "..(GetSpellInfo(spellID) or ""));
-            for _, aura in ipairs(auras[count]) do
-                self:MarkAura(spellID, count);
-                self:ActivateOverlay(count, select(3,unpack(aura)));
-                self:AddGlow(spellID, select(11,unpack(aura)));
-            end
-        elseif (
-            -- Aura is already visible
-            (currentlyActiveOverlay)
-        and
-            -- Aura is re-applied
-            (auraRefresh)
-        and
-            -- The number of stacks is supported
-            (auras[count])
-        ) then
-            -- Reactivate aura timer
-            self:Debug(Module, "Refreshing aura of "..spellID.." "..(GetSpellInfo(spellID) or ""));
-            self:RefreshOverlayTimer(spellID);
-        elseif (
-            -- Aura is already visible but its number of stack changed
-            (currentlyActiveOverlay and currentlyActiveOverlay ~= count)
-        and
-            -- The new stack count allows it to be visible
-            ((auraApplied or auraRemoved) and (count and count > 0))
-        and
-            -- The number of stacks is supported
-            (auras[count])
-        ) then
-            -- Deactivate old aura and activate the new one
-            self:Debug(Module, "Changing number of stacks from "..tostring(currentlyActiveOverlay).." to "..count.." for aura "..spellID.." "..(GetSpellInfo(spellID) or ""));
-            self:DeactivateOverlay(spellID);
-            self:RemoveGlow(spellID);
-            self:MarkAura(spellID, count); -- Call MarkAura after DeactivateOverlay, because DeactivateOverlay may reset its aura marker
-            for _, aura in ipairs(auras[count]) do
-                local texture, positions, scale, r, g, b, autoPulse, _, combatOnly = select(4,unpack(aura));
-                local forcePulsePlay = autoPulse;
-                self:ActivateOverlay(count, spellID, texture, positions, scale, r, g, b, autoPulse, forcePulsePlay, nil, combatOnly);
-                self:AddGlow(spellID, select(11,unpack(aura)));
-            end
-        elseif (
-            -- Aura is already visible and its number of stacks changed
-            (currentlyActiveOverlay and currentlyActiveOverlay ~= count)
-        and
-            ((auraApplied and count and count > 0) or auraRemoved)
-            -- If condition end up here, it means the previous 'if' was false
-            -- Which means either there is no stacks, or the number of stacks is not supported
-        ) then
-            -- Aura just disappeared or is not supported for this number of stacks
-            self:Debug(Module, "Removing aura of "..spellID.." "..(GetSpellInfo(spellID) or ""));
-            -- self:UnmarkAura(spellID); -- No need to unmark explicitly, because DeactivateOverlay does it automatically
-            self:DeactivateOverlay(spellID);
-            self:RemoveGlow(spellID);
+    local auraAppliedFirst = event == "SPELL_AURA_APPLIED";      -- For stackable auras: first stack applied; for unstackable auras: buff applied
+    local auraAppliedDose  = event == "SPELL_AURA_APPLIED_DOSE"; -- For stackable auras: second stack applied or beyond; for unstackable auras: N/A
+    local auraRemovedLast  = event == "SPELL_AURA_REMOVED";      -- For stackable auras: removed last remaining stack; for unstackable auras: buff removed
+    local auraRemovedDose  = event == "SPELL_AURA_REMOVED_DOSE"; -- For stackable auras: removed a stack, but there is at least one stack left; for unstackable auras: N/A
+
+    local count = 0;
+    if not auras[0] then
+        -- If there is no aura with stacks == 0, this must mean that this aura is stackable
+        -- To handle stackable auras, we must find the aura (ugh!) to get its number of stacks
+        -- In an ideal world, we'd use a stack count from the combat log which, unfortunately, is unavailable
+        count = select(3, self:FindPlayerAuraByID(spellID)) or 0;
+        -- Please note, the opposite is not necessarily true:
+        -- if an aura is defined with stacks == 0, it does not guarantee that the aura is not stackable
+        -- it means that the aura is count-agnostic, meaning we don't care how many count it has
+        -- in other words, the only thing that matters is whether or not the buff is found, independently of its number of stacks
+    end
+
+    --[[ Check if the spell is currently displayed, and if yes, with which count
+    Returned count will always be zero if tracking a count-agnostic aura (because the above if/then/else statement will be skipped)
+    Possible values:
+    - 1 or more, if the aura is displayed and it is a stackable aura, in which case the value indicates the number of stacks
+    - 0, if the aura is displayed and either the aura is not stackable or the effect is count-agnostic
+    - nil, if the aura is not displayed
+    ]]
+    local displayedCount = self:GetAuraMarker(spellID);
+    local isDisplayed = displayedCount ~= nil;
+    if (
+        -- Aura not visible yet
+        (not isDisplayed)
+    and
+        --[[ Aura is enabled, either because:
+        - it was added (auraAppliedFirst)
+        - or was upgraded (auraAppliedDose)
+        - or was downgraded but still visible (auraRemovedDose)
+        ]]
+        (auraApplied or auraRemovedDose)
+    and
+        -- The number of stacks is supported
+        (auras[count])
+    ) then
+        -- Activate aura
+        self:Debug(Module, "Activating aura of "..spellID.." "..(GetSpellInfo(spellID) or ""));
+        for _, aura in ipairs(auras[count]) do
+            self:MarkAura(spellID, count);
+            self:ActivateOverlay(count, select(3,unpack(aura)));
+            self:AddGlow(spellID, select(11,unpack(aura)));
         end
+    elseif (
+        -- Aura is already visible
+        (isDisplayed)
+    and
+        -- Aura is re-applied
+        (auraRefresh)
+    and
+        -- The number of stacks is supported
+        (auras[count])
+    ) then
+        -- Reactivate aura timer
+        self:Debug(Module, "Refreshing aura of "..spellID.." "..(GetSpellInfo(spellID) or ""));
+        self:RefreshOverlayTimer(spellID);
+    elseif (
+        -- Aura is already visible
+        (isDisplayed)
+    and
+        --[[ Its number of stacks changed
+        Note: if the aura is count-agnostic, this test will always return false, which suits us
+        When an aura is count-agnostic, we don't care when an aura goes from count A to count B because, by definition, the exact count does not matter
+        ]]
+        (displayedCount ~= count)
+    and
+        -- The new stack count allows it to be visible
+        (auraApplied or auraRemovedDose)
+    and
+        -- The number of stacks is supported
+        (auras[count])
+    ) then
+        -- Deactivate old aura and activate the new one
+        self:Debug(Module, "Changing number of stacks from "..tostring(displayedCount).." to "..count.." for aura "..spellID.." "..(GetSpellInfo(spellID) or ""));
+        self:DeactivateOverlay(spellID);
+        self:RemoveGlow(spellID);
+        self:MarkAura(spellID, count); -- Call MarkAura after DeactivateOverlay, because DeactivateOverlay may reset its aura marker
+        for _, aura in ipairs(auras[count]) do
+            local texture, positions, scale, r, g, b, autoPulse, _, combatOnly = select(4,unpack(aura));
+            local forcePulsePlay = autoPulse;
+            self:ActivateOverlay(count, spellID, texture, positions, scale, r, g, b, autoPulse, forcePulsePlay, nil, combatOnly);
+            self:AddGlow(spellID, select(11,unpack(aura)));
+        end
+    elseif (
+        -- Aura is already visible
+        (isDisplayed)
+    and
+        --[[ The aura should not be visible, either because:
+        - the aura is completely removed (auraRemovedLast)
+        - or the aura has changed stacks to an unsupported stack count
+        Note: a count-agnostic aura will have its count == 0, in which case the 'stack change test' will always return false, which suits us
+        A count-agnostic aura only cares whether the buff is active or not, the exact count does not matter
+        Because of this, it doesn't make any sense to e.g. "remove the aura because the new number of stacks is unsupported"
+        If you wonder when it is possible to deactivate an aura-agnostic effect, the answer is simple: when it is completely removed (auraRemovedLast)
+        ]]
+        (auraRemovedLast or ((auraAppliedDose or auraRemovedDose) and displayedCount ~= count and not auras[count]))
+    ) then
+        -- Aura just disappeared or is not supported for this number of stacks
+        self:Debug(Module, "Removing aura of "..spellID.." "..(GetSpellInfo(spellID) or ""));
+        -- self:UnmarkAura(spellID); -- No need to unmark explicitly, because DeactivateOverlay does it automatically
+        self:DeactivateOverlay(spellID);
+        self:RemoveGlow(spellID);
     end
 end
 

--- a/components/util.lua
+++ b/components/util.lua
@@ -16,6 +16,10 @@ local GetTalentInfo = GetTalentInfo
 local GetTime = GetTime
 local UnitAura = UnitAura
 
+--[[
+    Logging functions
+]]
+
 function SAO.Error(self, prefix, msg, ...)
     print(WrapTextInColor("**SAO** -"..prefix.."- "..msg, RED_FONT_COLOR), ...);
 end
@@ -49,6 +53,10 @@ function SAO.TraceThrottled(self, key, prefix, ...)
     end
 end
 
+--[[
+    Global Cooldown
+]]
+
 -- Get the Global Cooldown duration
 function SAO.GetGCD(self)
     if self:IsEra() or self:IsTBC() then
@@ -66,10 +74,14 @@ function SAO.GetGCD(self)
     end
 end
 
+--[[
+    Label builders
+]]
+
 -- Utility function to write a formatted 'number of stacks' text, translated with the client's locale
 -- SAO:NbStacks(4) -- "4 Stacks"
 -- SAO:NbStacks(7,9) -- "7-9 Stacks"
-function SAO.NbStacks(self, minStacks, maxStacks)
+function SAO:NbStacks(minStacks, maxStacks)
     if maxStacks then
         return string.format(CALENDAR_TOOLTIP_DATE_RANGE, tostring(minStacks), string.format(STACKS, maxStacks));
     end
@@ -77,9 +89,34 @@ function SAO.NbStacks(self, minStacks, maxStacks)
 end
 
 -- Simple function telling something was updated recently
-function SAO.RecentlyUpdated(self)
+function SAO:RecentlyUpdated()
     return WrapTextInColor(KBASE_RECENTLY_UPDATED, GREEN_FONT_COLOR);
 end
+
+local function tr(translations)
+    local locale = GetLocale();
+    return translations[locale] or translations[locale:sub(1,2)] or translations["en"];
+end
+
+-- Get the "Heating Up" localized buff name
+function SAO:translateHeatingUp()
+    local heatingUpTranslations = {
+        ["en"] = "Heating Up",
+        ["de"] = "Aufwärmen",
+        ["fr"] = "Réchauffement",
+        ["es"] = "Calentamiento",
+        ["ru"] = "Разогрев",
+        ["it"] = "Riscaldamento",
+        ["pt"] = "Aquecendo",
+        ["ko"] = "열기",
+        ["zh"] = "热力迸发",
+    };
+    return tr(heatingUpTranslations);
+end
+
+--[[
+    Time utility functions
+]]
 
 -- Utility function to assume times are identical or almost identical
 function SAO.IsTimeAlmostEqual(self, t1, t2, delta)

--- a/components/util.lua
+++ b/components/util.lua
@@ -114,6 +114,23 @@ function SAO:translateHeatingUp()
     return tr(heatingUpTranslations);
 end
 
+-- Get the "Debuff" localized text
+function SAO:translateDebuff()
+    local debuffTranslations = {
+        ["en"] = "Debuff",
+        ["de"] = "Schwächung",
+        ["fr"] = "Affaiblissement",
+        ["es"] = "Perjuicio",
+        ["ru"] = "Отрицательный эффект",
+        ["it"] = "Penalità",
+        ["pt"] = "Penalidade",
+        ["ko"] = "약화",
+        ["zh"] = "负面",
+        ["zhTW"] = "減益",
+    };
+    return tr(debuffTranslations);
+end
+
 --[[
     Time utility functions
 ]]

--- a/options/InterfaceOptionsPanels.xml
+++ b/options/InterfaceOptionsPanels.xml
@@ -3,25 +3,12 @@
   <Script file="InterfaceOptionsPanels.lua"/>
 
   <Frame name="SpellActivationOverlayOptionsPanel" hidden="true" parent="InterfaceOptionsFramePanelContainer">
-    <Layers>
-      <Layer level="ARTWORK">
-        <FontString name="$parentTitle" text="DISPLAY_LABEL" inherits="GameFontNormalLarge" justifyH="LEFT" justifyV="TOP">
-          <Anchors>
-            <Anchor point="TOPLEFT">
-              <Offset>
-                <AbsDimension x="16" y="-16"/>
-              </Offset>
-            </Anchor>
-          </Anchors>
-        </FontString>
-      </Layer>
-    </Layers>
     <Frames>
       <Slider name="$parentSpellAlertOpacitySlider" inherits="OptionsSliderTemplate">
         <Anchors>
-          <Anchor point="TOPLEFT" relativeTo="$parentTitle" relativePoint="BOTTOMLEFT">
+          <Anchor point="TOPLEFT">
             <Offset>
-              <AbsDimension x="24" y="-32"/>
+              <AbsDimension x="40" y="-32"/>
             </Offset>
           </Anchor>
         </Anchors>
@@ -142,7 +129,7 @@
         <Anchors>
           <Anchor point="TOPLEFT" relativeTo="$parentSpellAlertSoundSlider" relativePoint="BOTTOMLEFT">
             <Offset>
-              <AbsDimension x="-24" y="-32"/>
+              <AbsDimension x="-24" y="-24"/>
             </Offset>
           </Anchor>
         </Anchors>

--- a/options/classoptions.lua
+++ b/options/classoptions.lua
@@ -157,8 +157,17 @@ function SAO.AddOption(self, optionType, auraID, id, subValues, applyTextFunc, t
         SpellActivationOverlayOptionsPanel.additionalCheckboxes[optionType] = { cb };
     else
         -- Each subsequent checkbox is anchored to the previous one
-        local lastCheckBox = SpellActivationOverlayOptionsPanel.additionalCheckboxes[optionType][#SpellActivationOverlayOptionsPanel.additionalCheckboxes[optionType]];
-        cb:SetPoint("TOPLEFT", lastCheckBox, "BOTTOMLEFT", 0, 0);
+        local nbCheckboxes = #SpellActivationOverlayOptionsPanel.additionalCheckboxes[optionType];
+        local lastCheckBox = SpellActivationOverlayOptionsPanel.additionalCheckboxes[optionType][nbCheckboxes];
+        if optionType ~= "glow" or nbCheckboxes ~= 14 then
+            cb:SetPoint("TOPLEFT", lastCheckBox, "BOTTOMLEFT", 0, 0);
+        else
+            -- Glowing buttons may be too numerous (more than 14)
+            -- When this happens, a second column is used, and the first column is offset to the left
+            local firstCb = SpellActivationOverlayOptionsPanel.additionalCheckboxes[optionType][1];
+            firstCb:SetPoint("TOPLEFT", firstAnchor.frame, "BOTTOMLEFT", (firstAnchor.xOffset or 0) - 32, firstAnchor.yOffset or 0);
+            cb:SetPoint("TOPLEFT", firstAnchor.frame, "BOTTOMLEFT", (firstAnchor.xOffset or 0) + 320, firstAnchor.yOffset or 0);
+        end
         table.insert(SpellActivationOverlayOptionsPanel.additionalCheckboxes[optionType], cb);
     end
 

--- a/options/variants.lua
+++ b/options/variants.lua
@@ -47,7 +47,7 @@ function SAO.TextureVariantValue(self, texture, horizontal, suffix)
 
     local width = horizontal and 6 or 3;
     if (suffix) then
-        width = width+1+#suffix;
+        width = width+1+strlenutf8(suffix);
     end
 
     return {
@@ -92,7 +92,7 @@ function SAO.StringVariantValue(self, items, valuePrefix, getTextFunc)
         text = text:sub(3);
     end
 
-    local width = ceil(#text*0.4);
+    local width = ceil(strlenutf8(text)*0.4);
 
     return {
         value = valuePrefix..value,


### PR DESCRIPTION
Main focus on Mage for Cataclysm. This class was the first to support Cataclysm, and did not get much love since then.

Fixes #257.
Fixes #250.
Fixes #240.
Fixes #288 (or at least, greatly improves it).
Fixes #285 (or at least, greatly improves it).