### PR TITLE
Mists of Pandaria

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -149,6 +149,7 @@
         "RED_FONT_COLOR",
         "SMALL",
         "SOUNDKIT",
+        "SPECIALIZATION",
         "SPELL_ALERT_OPACITY",
         "STACKS",
         "STATUS_TEXT_BOTH",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -68,6 +68,7 @@
         // WoW game API
         "C_Engraving",
         "C_Item",
+        "C_SpecializationInfo",
         "C_Timer",
         "C_UnitAuras",
         "CombatLogGetCurrentEventInfo",
@@ -104,6 +105,7 @@
         "UnitAura",
         "UnitCanAttack",
         "UnitClass",
+        "UnitClassBase",
         "UnitDebuff",
         "UnitExists",
         "UnitGUID",
@@ -132,8 +134,10 @@
         "KBASE_RECENTLY_UPDATED",
         "LARGE",
         "LIGHTBLUE_FONT_COLOR",
+        "MAX_NUM_TALENT_TIERS",
         "NEAR",
         "NONE",
+        "NUM_TALENT_COLUMNS",
         "NUM_STANCE_SLOTS",
         "OFF",
         "ON_COOLDOWN",
@@ -151,10 +155,11 @@
         "UNKNOWN",
         "WARNING_FONT_COLOR",
         "WOW_PROJECT_ID",
-        "WOW_PROJECT_CLASSIC",
         "WOW_PROJECT_BURNING_CRUSADE_CLASSIC",
-        "WOW_PROJECT_WRATH_CLASSIC",
-        "WOW_PROJECT_CATACLYSM_CLASSIC"
+        "WOW_PROJECT_CATACLYSM_CLASSIC",
+        "WOW_PROJECT_CLASSIC",
+        "WOW_PROJECT_MISTS_CLASSIC",
+        "WOW_PROJECT_WRATH_CLASSIC"
     ],
     "workbench.colorCustomizations": {
         "activityBar.activeBackground": "#4f71dc",

--- a/SpellActivationOverlay.lua
+++ b/SpellActivationOverlay.lua
@@ -37,7 +37,7 @@ function SpellActivationOverlay_OnLoad(self)
 
 	local className, classFile, classId = UnitClass("player");
 	local class = SAO.Class[classFile];
-	if class then
+	if class and not class.IsDisabled then
 		class.Intrinsics = { className, classFile, classId };
 		SAO.CurrentClass = class;
 
@@ -49,8 +49,13 @@ function SpellActivationOverlay_OnLoad(self)
 		end
 	else
 		local currentClass = tostring(select(1, UnitClass("player")));
-		SAO:Error(Module, SAO:unsupportedClass(), currentClass);
-		SAO.Shutdown:EnableCategory("UNSUPPORTED_CLASS");
+		if class and class.IsDisabled then
+			SAO:Warn(Module, string.format(SAO:disabledClass(), currentClass));
+			SAO.Shutdown:EnableCategory("DISABLED_CLASS");
+		else
+			SAO:Error(Module, SAO:unsupportedClass(), currentClass);
+			SAO.Shutdown:EnableCategory("UNSUPPORTED_CLASS");
+		end
 	end
 
 	if ( SAO.IsCata() ) then

--- a/_script/package.sh
+++ b/_script/package.sh
@@ -299,6 +299,37 @@ zipproject cata "$VERSION_TOC_VERSION"
 
 cdup
 
+# Release mop version
+MOP_BUILD_VERSION=50500
+mkproject mop $MOP_BUILD_VERSION
+
+prunecopyright Cataclysm Pandaria
+
+TEXTURES_NOT_FOR_MOP=(
+arcane_missiles_1
+arcane_missiles_2
+arcane_missiles_3
+fulmination
+maelstrom_weapon_6
+maelstrom_weapon_7
+maelstrom_weapon_8
+maelstrom_weapon_9
+maelstrom_weapon_10
+monk_serpent
+raging_blow
+tooth_and_claw
+white_tiger
+$(texbelow 898423 450914 450915)
+)
+prunetex "${TEXTURES_NOT_FOR_MOP[@]}"
+
+SOUNDS_NOT_FOR_MOP=(UI_PowerAura_Generic)
+prunesound "${SOUNDS_NOT_FOR_MOP[@]}"
+
+zipproject mop "$VERSION_TOC_VERSION"
+
+cdup
+
 # Release Necrosis version
 NECROSIS_BUILD_VERSION=40402 # Version does not matter, toc will not be used
 mkproject necrosis $NECROSIS_BUILD_VERSION

--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@ Introducting Mists of Pandaria flavor!
 - Support for Death Knight's Dark Transformation
 - Support for Death Knight's Sudden Doom
 - Support for Death Knight's Glyph of Dark Succor
+- Support for Priest's Shadowform
 
 Known limitations:
 - Dark Transformation does not display an overlay, due to a game client issue

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,21 @@
 ## SpellActivationOverlay Changelog
 
+#### v2.4.1 (2025-05-xx)
+
+Shout-out to Flow who designed Shaman's 6-10 Maelstrom Weapon textures. Thanks!
+
+New Spell Alert
+- Warrior's Regicide (Season of Discovery)
+
+New Glowing Button
+- Warrior's Execute, during Regicide (Season of Discovery)
+
+Introducting Mists of Pandaria flavor!
+- The addon is still in very early stage
+
+There were significant changes which, hopefully, should not break anything.
+But in case it did break something, please to report issues. Thank you :)
+
 #### v2.4.0 (2025-05-11)
 
 Shout-out to fellow developers Skyward, Vanheden and Adal4. Thanks!
@@ -89,8 +105,8 @@ Mage
 
 Shaman
 - Shaman's Molten Blast option was displayed twice (Season of Discovery)
-- Shaman's Maelstorm Weapon no longer empowers Chain Heal (SoD)
-- Shaman's Maelstorm Weapon no longer empowers Healing Wave (SoD)
+- Shaman's Maelstrom Weapon no longer empowers Chain Heal (SoD)
+- Shaman's Maelstrom Weapon no longer empowers Healing Wave (SoD)
 
 Bug Fixes
 - Lua errors caused by action buttons should no longer happen

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,17 @@ New Glowing Button
 
 Introducting Mists of Pandaria flavor!
 - The addon is still in very early stage
+- Support for Death Knight's Crimson Scourge
+- Support for Death Knight's Will of the Necropolis
+- Support for Death Knight's Rime
+- Support for Death Knight's Killing Machine
+- Support for Death Knight's Dark Transformation
+- Support for Death Knight's Sudden Doom
+- Support for Death Knight's Glyph of Dark Succor
+
+Known limitations:
+- Dark Transformation does not display an overlay, due to a game client issue
+- Dark Succor will glow Death Strike in all presences, including Blood Presence
 
 There were significant changes which, hopefully, should not break anything.
 But in case it did break something, please to report issues. Thank you :)

--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,10 @@ Introducting Mists of Pandaria flavor!
 - Support for Death Knight's Sudden Doom
 - Support for Death Knight's Glyph of Dark Succor
 - Support for Priest's Shadowform
+- Support for Warrior's Overpower
+- Support for Warrior's Execute
+- Support for Warrior's Revenge
+- Support for Warrior's Victory Rush
 
 Known limitations:
 - Dark Transformation does not display an overlay, due to a game client issue

--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,10 @@ Introducting Mists of Pandaria flavor!
 - Support for Death Knight's Dark Transformation
 - Support for Death Knight's Sudden Doom
 - Support for Death Knight's Glyph of Dark Succor
+- Support for Mage's Freeze debuff
+- Support for Paladin's Hammer of Wrath
+- Support for Paladin's Exorcism
+- Support for Paladin's Holy Shock
 - Support for Priest's Shadowform
 - Support for Warrior's Overpower
 - Support for Warrior's Execute
@@ -28,6 +32,7 @@ Introducting Mists of Pandaria flavor!
 Known limitations:
 - Dark Transformation does not display an overlay, due to a game client issue
 - Dark Succor will glow Death Strike in all presences, including Blood Presence
+- Mage's Freeze debuff does not track Shaman's Freeze debuff, from Frozen Power
 
 There were significant changes which, hopefully, should not break anything.
 But in case it did break something, please to report issues. Thank you :)

--- a/classes/deathknight.lua
+++ b/classes/deathknight.lua
@@ -1,9 +1,14 @@
 local AddonName, SAO = ...
 
+local DK_SPEC_BLOOD = -1;
+local DK_SPEC_FROST = -2;
+local DK_SPEC_UNHOLY = -4;
+
 local bloodBoil = 48721;
 local boneShield = 49222;
 local darkTransformation = 63560;
 local deathCoil = 47541;
+local deathStrike = 49998;
 local frostStrike = 49143;
 local howlingBlast = 49184;
 local icyTouch = 45477;
@@ -22,13 +27,15 @@ local function useRuneStrike()
 end
 
 local function useBoneShield()
+    local boneShieldTalent = SAO.IsMoP() and DK_SPEC_BLOOD or boneShield;
+
     SAO:CreateEffect(
         "bone_shield",
-        SAO.CATA,
+        SAO.CATA + SAO.MOP,
         boneShield,
         "aura",
         {
-            talent = boneShield,
+            talent = boneShieldTalent,
             requireTalent = true,
             actionUsable = true,
             combatOnly = true,
@@ -38,49 +45,60 @@ local function useBoneShield()
 end
 
 local function useRime()
+    local rimeTalent = SAO.IsMoP() and 59057 or 49188;
+
     SAO:CreateEffect(
         "rime",
-        SAO.WRATH + SAO.CATA,
+        SAO.WRATH + SAO.CATA + SAO.MOP,
         59052, -- Freezing Fog (buff)
         "aura",
         {
-            talent = 49188, -- Rime (talent)
+            talent = rimeTalent,
             overlay = { texture = "rime", position = "Top" },
             buttons = {
                 [SAO.WRATH] = howlingBlast,
                 [SAO.CATA] = { howlingBlast, icyTouch },
+                -- [SAO.MOP] = { howlingBlast, icyTouch }, -- Buttons already glowing natively
             },
         }
     );
 end
 
 local function useKillingMachine()
+    local killinsMachineTalent = SAO.IsMoP() and 51128 or 51123;
+
     SAO:CreateEffect(
         "killing_machine",
-        SAO.WRATH + SAO.CATA,
+        SAO.WRATH + SAO.CATA + SAO.MOP,
         51124, -- Killing Machine (buff)
         "aura",
         {
-            talent = 51123, -- Killing Machine (talent)
+            talent = killinsMachineTalent,
             overlay = { texture = "killing_machine", position = "Left + Right (Flipped)" },
             buttons = {
                 [SAO.WRATH] = { icyTouch, frostStrike, howlingBlast },
                 [SAO.CATA] = { frostStrike, obliterate },
+                -- [SAO.MOP] = { frostStrike, obliterate }, -- Buttons already glowing natively
             },
         }
     );
 end
 
 local function useCrimsonScourge()
+    local crimsonScourgeTalent = SAO.IsMoP() and 81136 or 81135;
+
     SAO:CreateEffect(
         "crimson_scourge",
-        SAO.CATA,
+        SAO.CATA + SAO.MOP,
         81141, -- Crimson Scourge (buff)
         "aura",
         {
-            talent = 81135, -- Crimson Scourge (talent)
+            talent = crimsonScourgeTalent,
             overlay = { texture = "blood_boil", position = "Left + Right (Flipped)" },
-            button = bloodBoil,
+            buttons = {
+                [SAO.CATA] = bloodBoil,
+                -- [SAO.MOP] = bloodBoil, -- Button already glowing natively
+            },
         }
     );
 end
@@ -88,40 +106,65 @@ end
 local function useDarkTransformation()
     SAO:CreateEffect(
         "dark_transformation",
-        SAO.CATA,
+        SAO.CATA + SAO.MOP,
         93426, -- Dark Transformation proc for Native SHOW event
         "native",
         {
             overlay = { texture = "dark_transformation", position = "Top" },
-            button = darkTransformation,
+            buttons = {
+                [SAO.CATA] = darkTransformation,
+                -- [SAO.MOP] = darkTransformation, -- Button already glowing natively
+            }
         }
     );
 end
 
 local function useSuddenDoom()
+    local suddenDoomTalent = SAO.IsMoP() and 49530 or 81340;
+
     SAO:CreateEffect(
         "sudden_doom",
-        SAO.CATA,
+        SAO.CATA + SAO.MOP,
         81340, -- Sudden Doom (buff)
         "aura",
         {
-            talent = 49018, -- Sudden Doom (talent)
+            talent = suddenDoomTalent,
             overlay = { texture = "sudden_doom", position = "Left + Right (Flipped)" },
-            button = deathCoil,
+            buttons = {
+                [SAO.CATA] = deathCoil,
+                -- [SAO.MOP] = deathCoil, -- Button already glowing natively
+            },
         }
     );
 end
 
 local function useWotn()
+    local wotnTalent = SAO.IsMoP() and 81164 or 52284;
+
     SAO:CreateEffect(
         "wotn",
-        SAO.CATA,
+        SAO.CATA + SAO.MOP,
         96171, -- Will of the Necropolis (buff)
         "aura",
         {
-            talent = 52284, -- Will of the Necropolis (talent)
+            talent = wotnTalent,
             overlay = { texture = "necropolis", position = "Top" },
-            button = runeTap,
+            buttons = {
+                [SAO.CATA] = runeTap,
+                -- [SAO.MOP] = runeTap, -- Button already glowing natively
+            },
+        }
+    );
+end
+
+local function useDarkSuccor()
+    SAO:CreateEffect(
+        "dark_succor",
+        SAO.MOP,
+        101568, -- Dark Succor (buff)
+        "aura",
+        {
+            button = deathStrike,
         }
     );
 end
@@ -142,6 +185,9 @@ local function registerClass(self)
     -- Unholy
     useDarkTransformation();
     useSuddenDoom();
+
+    -- Glyphs
+    useDarkSuccor();
 end
 
 SAO.Class["DEATHKNIGHT"] = {

--- a/classes/druid.lua
+++ b/classes/druid.lua
@@ -489,4 +489,5 @@ SAO.Class["DRUID"] = {
     ["COMBAT_LOG_EVENT_UNFILTERED"] = customCLEU,
     ["UPDATE_SHAPESHIFT_FORM"] = updateShapeshift,
     ["PLAYER_ENTERING_WORLD"] = customLoad,
+    IsDisabled = SAO.IsMoP(),
 }

--- a/classes/hunter.lua
+++ b/classes/hunter.lua
@@ -248,4 +248,5 @@ end
 
 SAO.Class["HUNTER"] = {
     ["Register"] = registerClass,
+    IsDisabled = SAO.IsMoP(),
 }

--- a/classes/mage.lua
+++ b/classes/mage.lua
@@ -4,7 +4,6 @@ local Module = "mage"
 -- Optimize frequent calls
 local CombatLogGetCurrentEventInfo = CombatLogGetCurrentEventInfo
 local GetSpellInfo = GetSpellInfo
-local GetTalentInfo = GetTalentInfo
 local UnitCanAttack = UnitCanAttack
 local UnitDebuff = UnitDebuff
 local UnitExists = UnitExists
@@ -102,7 +101,7 @@ HotStreakHandler.hasHotStreakTalent = function(self)
     -- Talent information must include at least one point in Hot Streak
     -- This may not be accurate, but it's almost impossible to do better
     -- Not to mention, almost no one will play with only 1 or 2 points
-    local rank = select(5, GetTalentInfo(self.talent[1], self.talent[2]));
+    local rank = SAO:GetNbTalentPoints(self.talent[1], self.talent[2]);
     return rank > 0;
 end
 

--- a/classes/priest.lua
+++ b/classes/priest.lua
@@ -1,5 +1,9 @@
 local AddonName, SAO = ...
 
+local PRIEST_SPEC_DISCIPLINE = -1;
+local PRIEST_SPEC_HOLY = -2;
+local PRIEST_SPEC_SHADOW = -4;
+
 local bindingHeal = 401937;
 local flashHeal = 2061;
 local flashHealNoMana = 101062;
@@ -56,6 +60,7 @@ local function useShadowform()
         shadowform,
         "aura",
         {
+            talent = SAO.IsMoP() and PRIEST_SPEC_SHADOW or nil,
             requireTalent = true,
             combatOnly = true,
             button = { stacks = -1 },

--- a/classes/rogue.lua
+++ b/classes/rogue.lua
@@ -204,4 +204,5 @@ SAO.Class["ROGUE"] = {
     ["Register"] = registerClass,
     ["PLAYER_LOGIN"] = customLogin,
     ["COMBAT_LOG_EVENT_UNFILTERED"] = customCLEU,
+    IsDisabled = SAO.IsMoP(),
 }

--- a/classes/shaman.lua
+++ b/classes/shaman.lua
@@ -447,4 +447,5 @@ SAO.Class["SHAMAN"] = {
     ["PLAYER_REGEN_ENABLED"] = deactivateRollingThunderGlow,
     ["PLAYER_REGEN_DISABLED"] = activateRollingThunderGlow,
     ["PLAYER_LOGIN"] = deactivateRollingThunderGlow,
+    IsDisabled = SAO.IsMoP(),
 }

--- a/classes/shaman.lua
+++ b/classes/shaman.lua
@@ -2,7 +2,6 @@ local AddonName, SAO = ...
 
 -- Optimize frequent calls
 local CombatLogGetCurrentEventInfo = CombatLogGetCurrentEventInfo
-local GetTalentInfo = GetTalentInfo
 local UnitGUID = UnitGUID
 
 -- Detect Rolling Thunder stacks
@@ -350,7 +349,7 @@ local function registerClass(self)
 
         local powerSurgeRightTextureFunc = function()
             local hasElementalFocusOption = SpellActivationOverlayDB.classes["SHAMAN"]["alert"][elementalFocusBuff][0];
-            local canProcElementalFocus = efTalentTab and efTalentIndex and select(5, GetTalentInfo(efTalentTab, efTalentIndex)) > 0;
+            local canProcElementalFocus = efTalentTab and efTalentIndex and self:GetNbTalentPoints(efTalentTab, efTalentIndex) > 0;
             if hasElementalFocusOption and canProcElementalFocus then
                 return;
             end

--- a/classes/warlock.lua
+++ b/classes/warlock.lua
@@ -344,4 +344,5 @@ SAO.Class["WARLOCK"] = {
     ["PLAYER_TARGET_CHANGED"] = retarget,
     ["UNIT_HEALTH"] = unitHealth,
     ["UNIT_HEALTH_FREQUENT"] = unitHealthFrequent,
+    IsDisabled = SAO.IsMoP(),
 }

--- a/classes/warrior.lua
+++ b/classes/warrior.lua
@@ -318,8 +318,13 @@ local ExecuteHandler = {
 }
 
 local function customLogin(self, ...)
+    if SAO.IsMoP() then
+        -- No handlers for Mists of Pandaria: all abilities are available in all stances
+        return;
+    end
+
     local overpowerName = GetSpellInfo(overpower);
-    if (overpowerName) then
+    if overpowerName then
         -- Overpower is used for OverpowerHandler, detecting when the target dodges
         OverpowerHandler:init(overpower, overpowerName);
 
@@ -334,12 +339,12 @@ local function customLogin(self, ...)
     end
 
     local revengeName = GetSpellInfo(revenge);
-    if (revengeName) then
+    if revengeName then
         RevengeHandler:init(revenge, revengeName);
     end
 
     local executeName = GetSpellInfo(execute);
-    if (executeName) then
+    if executeName then
         ExecuteHandler:init(execute, executeName);
     end
 end
@@ -388,7 +393,7 @@ local function useOverpower()
         overpower,
         "counter",
         {   -- Lazy evaluation for variants, because they are created later on
-            buttonOption = { variants = function() return OverpowerHandler.variants end },
+            buttonOption = not SAO.IsMoP() and { variants = function() return OverpowerHandler.variants end } or nil,
         }
     );
 end
@@ -400,7 +405,7 @@ local function useExecute()
         execute,
         "counter",
         {   -- Lazy evaluation for variants, because they are created later on
-            buttonOption = { variants = function() return ExecuteHandler.variants end },
+            buttonOption = not SAO.IsMoP() and { variants = function() return ExecuteHandler.variants end } or nil,
         }
     );
 end
@@ -412,7 +417,7 @@ local function useRevenge()
         revenge,
         "counter",
         {   -- Lazy evaluation for variants, because they are created later on
-            buttonOption = { variants = function() return RevengeHandler.variants end },
+            buttonOption = not SAO.IsMoP() and { variants = function() return RevengeHandler.variants end } or nil,
         }
     );
 end
@@ -420,7 +425,7 @@ end
 local function useVictoryRush()
     SAO:CreateEffect(
         "victory_rush",
-        SAO.SOD + SAO.TBC + SAO.WRATH + SAO.CATA,
+        SAO.ALL_PROJECTS - SAO.ERA, -- includes SAO.SOD, then SAO.TBC and later
         victoryRush,
         "counter"
     );

--- a/components/counter.lua
+++ b/components/counter.lua
@@ -4,7 +4,6 @@ local Module = "counter"
 -- Optimize frequent calls
 local GetSpellCooldown = GetSpellCooldown
 local GetSpellPowerCost = GetSpellPowerCost
-local GetTalentInfo = GetTalentInfo
 local GetTime = GetTime
 local InCombatLockdown = InCombatLockdown
 local IsUsableSpell = IsUsableSpell
@@ -148,7 +147,7 @@ function SAO.CheckCounterAction(self, spellID, bucketName, talent, combatOnly)
     SAO:TraceThrottled(spellID, Module, "CheckCounterAction "..tostring(spellID).." "..tostring(bucketName).." "..tostring(talent).." "..tostring(combatOnly));
 
     if (talent) then
-        local rank = select(5, GetTalentInfo(talent[1], talent[2]));
+        local rank = self:GetNbTalentPoints(talent[1], talent[2]);
         if (not (rank > 0)) then
             -- 0 points spent in the required Talent
             self:SetCounterStatus(spellID, bucketName, 'off');

--- a/components/project.lua
+++ b/components/project.lua
@@ -8,7 +8,8 @@ SAO.SOD = 512
 SAO.TBC = 1024
 SAO.WRATH = 2048
 SAO.CATA = 4096
-SAO.ALL_PROJECTS = SAO.ERA+SAO.SOD+SAO.TBC+SAO.WRATH+SAO.CATA
+SAO.MOP = 8192
+SAO.ALL_PROJECTS = SAO.ERA+SAO.SOD+SAO.TBC+SAO.WRATH+SAO.CATA+SAO.MOP
 
 function SAO.IsEra()
     return WOW_PROJECT_ID == WOW_PROJECT_CLASSIC;
@@ -26,6 +27,10 @@ function SAO.IsCata()
     return WOW_PROJECT_ID == WOW_PROJECT_CATACLYSM_CLASSIC;
 end
 
+function SAO.IsMoP()
+    return WOW_PROJECT_ID == WOW_PROJECT_MISTS_CLASSIC;
+end
+
 function SAO.IsSoD()
     return WOW_PROJECT_ID == WOW_PROJECT_CLASSIC and C_Engraving and C_Engraving.IsEngravingEnabled()
 end
@@ -40,6 +45,7 @@ function SAO.IsProject(projectFlags)
         bit.band(projectFlags, SAO.SOD) ~= 0 and SAO.IsSoD() or
         bit.band(projectFlags, SAO.TBC) ~= 0 and SAO.IsTBC() or
         bit.band(projectFlags, SAO.WRATH) ~= 0 and SAO.IsWrath() or
-        bit.band(projectFlags, SAO.CATA) ~= 0 and SAO.IsCata()
+        bit.band(projectFlags, SAO.CATA) ~= 0 and SAO.IsCata() or
+        bit.band(projectFlags, SAO.MOP) ~= 0 and SAO.IsMoP()
     );
 end

--- a/components/shutdown.lua
+++ b/components/shutdown.lua
@@ -17,10 +17,20 @@ end
 
 local Categories = {
     UNSUPPORTED_CLASS = {
-        Priority = 1,
+        Priority = 0,
         Get = function()
             return {
                 Reason = SAO:unsupportedClass(),
+                Button = nil, -- There are no obvious action to suggest
+                DisableCondition = nil, -- There are no conditions: disabling is absolute
+            }
+        end,
+    },
+    DISABLED_CLASS = {
+        Priority = 1,
+        Get = function()
+            return {
+                Reason = SAO:disabledClass():gsub(" %%s", ""):gsub("%%s",""):gsub(" :%)", ""),
                 Button = nil, -- There are no obvious action to suggest
                 DisableCondition = nil, -- There are no conditions: disabling is absolute
             }

--- a/components/util.lua
+++ b/components/util.lua
@@ -191,6 +191,22 @@ function SAO:unsupportedClass()
     return tr(unsupportedClassTranslations);
 end
 
+-- Get the "Disabled class" localized text
+function SAO:disabledClass()
+    local unsupportedClassTranslations = {
+        ["en"] = "Disabled class %s while development is in progress.\nPlease come back soon :)",
+        ["de"] = "Deaktivierte Klasse %s, während der Entwicklungsphase.\nBitte kommen Sie bald wieder :)",
+        ["fr"] = "Classe %s désactivée pendant que le développement est en cours.\nRevenez bientôt :)",
+        ["es"] = "Clase %s desactivada mientras el desarrollo está en curso.\nVuelva pronto :)",
+        ["ru"] = "Класс %s отключен на время разработки.\nПожалуйста, вернитесь в ближайшее время :)",
+        ["it"] = "La classe %s è stata disabilitata mentre lo sviluppo è in corso.\nSi prega di tornare presto :)",
+        ["pt"] = "Classe %s desativada enquanto o desenvolvimento está em andamento.\nPor favor, volte em breve :)",
+        ["ko"] = "개발이 진행되는 동안 %s 클래스를 사용할 수 없습니다.\n곧 다시 돌아와주세요 :)",
+        ["zh"] = "开发过程中禁用了%s类。请尽快回来 :)",
+    };
+    return tr(unsupportedClassTranslations);
+end
+
 -- Get the "because of {reason}" localized text
 function SAO:becauseOf(reason)
     local becauseOfTranslations = {

--- a/components/util.lua
+++ b/components/util.lua
@@ -453,6 +453,10 @@ function SAO:GetTalentText(talentID)
         end
     else
         local spellName, _, spellIcon = GetSpellInfo(talentID);
+        if not spellName then
+            self:Error(Module, "Unknown spell for talentID "..tostring(talentID));
+            return nil;
+        end
         return "|T"..spellIcon..":0|t "..spellName;
     end
 end

--- a/options/defaults.lua
+++ b/options/defaults.lua
@@ -10,21 +10,21 @@ SAO.defaults = {
                 [51124] = { -- Killing Machine
                     [0] = true,
                 },
-                [81141] = { -- Crimson Scourge (Cataclysm)
+                [81141] = { -- Crimson Scourge (Cataclysm+)
                     [0] = true,
                 },
-                [81340] = { -- Sudden Doom (Cataclysm)
+                [81340] = { -- Sudden Doom (Cataclysm+)
                     [0] = true,
                 },
-                [93426] = { -- Dark Transformation (not an actual buff) (Cataclysm)
+                [93426] = { -- Dark Transformation (not an actual buff) (Cataclysm+)
                     [0] = true,
                 },
-                [96171] = { -- Will of the Necropolis (Cataclysm)
+                [96171] = { -- Will of the Necropolis (Cataclysm+)
                     [0] = true,
                 },
             },
             glow = {
-                [49222] = { -- Bone Shield (Cataclysm)
+                [49222] = { -- Bone Shield (Cataclysm+)
                     [49222] = false, -- Bone Shield
                 },
                 [56815] = { -- Rune Strike (Wrath)
@@ -36,21 +36,24 @@ SAO.defaults = {
                 },
                 [51124] = { -- Killing Machine
                     [49020] = true, -- Obliterate (not for Wrath)
-                    [45477] = true, -- Icy Touch (not for Cata)
+                    [45477] = true, -- Icy Touch (only for Wrath)
                     [49143] = true, -- Frost Strike
-                    [49184] = true, -- Howling Blast (not for Cata)
+                    [49184] = true, -- Howling Blast (only for Wrath)
                 },
-                [81141] = { -- Crimson Scourge (Cataclysm)
+                [81141] = { -- Crimson Scourge (Cataclysm+)
                     [48721] = true, -- Blood Boil
                 },
-                [81340] = { -- Sudden Doom (Cataclysm)
+                [81340] = { -- Sudden Doom (Cataclysm+)
                     [47541] = true, -- Death Coil
                 },
-                [93426] = { -- Dark Transformation (not an actual buff) (Cataclysm)
+                [93426] = { -- Dark Transformation (not an actual buff) (Cataclysm+)
                     [63560] = true, -- Dark Transformation
                 },
-                [96171] = { -- Will of the Necropolis (Cataclysm)
+                [96171] = { -- Will of the Necropolis (Cataclysm+)
                     [48982] = true, -- Rune Tap
+                },
+                [101568] = { -- Glyph of Dark Succor (MoP)
+                    [49998] = true, -- Death Strike
                 },
             }
         },

--- a/options/glowoptions.lua
+++ b/options/glowoptions.lua
@@ -3,7 +3,7 @@ local AddonName, SAO = ...
 local Module = "option"
 
 -- Add a checkbox for a glowing button
--- talentID is the spell ID of the associated talent; can be nil, meaning the button does not glow depending on a talent
+-- talentID is the spell ID of the associated talent; can be nil, meaning the button does not glow depending on a talent; can be negative for specs instead of talents
 -- spellID is the spell ID of the buff or action that triggers the button; if the button is a counter, spellID should match glowID
 -- glowID is the spell ID of the button(s) that will glow
 -- talentSubText is a string describing the specificity of this option, appended to talent text
@@ -13,8 +13,9 @@ local Module = "option"
 -- @note Options must be linked asap, not during loadOptions() which would be loaded only when the options panel is opened
 -- By linking options as soon as possible, before their respective RegisterAura() calls, options can be used by initial triggers, if any
 function SAO.AddGlowingOption(self, talentID, spellID, glowID, talentSubText, spellSubText, variants, hash) -- @todo use hash and testHash like overlay options
-    if (talentID and not GetSpellInfo(talentID)) or (not self:IsFakeSpell(glowID) and not GetSpellInfo(glowID)) then
-        if talentID and not GetSpellInfo(talentID) then
+    local talentText = talentID and self:GetTalentText(talentID);
+    if (talentID and not talentText) or (not self:IsFakeSpell(glowID) and not GetSpellInfo(glowID)) then
+        if talentID and not talentText then
             self:Debug(Module, "Skipping glowing option of talentID "..tostring(talentID).." because the spell does not exist");
         end
         if not self:IsFakeSpell(glowID) and not GetSpellInfo(glowID) then
@@ -42,12 +43,11 @@ function SAO.AddGlowingOption(self, talentID, spellID, glowID, talentSubText, sp
         -- Talent text
         local spellName, spellIcon;
         if (talentID and talentID ~= glowID) then
-            spellName, _, spellIcon = GetSpellInfo(talentID);
-            text = text.." |T"..spellIcon..":0|t "..spellName;
+            text = text.." "..talentText;
             if (talentSubText) then
                 text = text.." ("..talentSubText..")";
             end
-            text = text.." +"
+            text = text.." +";
         elseif (talentID and talentID == glowID and talentSubText) then
             self:Debug(Module, "Glowing option of glowID "..tostring(glowID).." has talent sub-text '"..talentSubText.."' but the text will be discarded because talentID matches glowID");
         end

--- a/options/overlayoptions.lua
+++ b/options/overlayoptions.lua
@@ -3,7 +3,7 @@ local AddonName, SAO = ...
 local Module = "option"
 
 -- Add a checkbox for an overlay
--- talentID is the spell ID of the associated talent
+-- talentID is the spell ID of the associated talent; can be negative for specs instead of talents
 -- auraID is the spell ID that triggers the overlay; it must match a spell ID of an aura registered with RegisterAura
 -- hash is the display hash expected for this option; use a numerical value as legacy option "stacks", including 0 for "any stacks"
 -- talentSubText is a string describing the specificity of this option
@@ -13,8 +13,9 @@ local Module = "option"
 -- @note Options must be linked asap, not during loadOptions() which would be loaded only when the options panel is opened
 -- By linking options as soon as possible, before their respective RegisterAura() calls, options can be used by initial triggers, if any
 function SAO.AddOverlayOption(self, talentID, auraID, hash, talentSubText, variants, testHash, testAuraID)
-    if not GetSpellInfo(talentID) or (not self:IsFakeSpell(auraID) and not GetSpellInfo(auraID)) then
-        if not GetSpellInfo(talentID) then
+    local talentText = self:GetTalentText(talentID);
+    if not talentText or (not self:IsFakeSpell(auraID) and not GetSpellInfo(auraID)) then
+        if not talentText then
             self:Debug(Module, "Skipping overlay option of talentID "..tostring(talentID).." because the spell does not exist");
         end
         if not self:IsFakeSpell(auraID) and not GetSpellInfo(auraID) then
@@ -49,8 +50,7 @@ function SAO.AddOverlayOption(self, talentID, auraID, hash, talentSubText, varia
         local text = WrapTextInColorCode(className, classColor);
 
         -- Talent text
-        local spellName, _, spellIcon = GetSpellInfo(talentID);
-        text = text.." |T"..spellIcon..":0|t "..spellName;
+        text = text.." "..talentText;
         local humanReadableHash = hashCalculator:toHumanReadableString();
         if humanReadableHash then
             text = text .. " ("..humanReadableHash..")";

--- a/options/variants.lua
+++ b/options/variants.lua
@@ -82,7 +82,7 @@ function SAO.StringVariantValue(self, items, valuePrefix, getTextFunc)
 
     if #items == 1 then
         value = tostring(items[1]);
-        text = string.format(RACE_CLASS_ONLY, getTextFunc(items[1]));
+        text = self:OnlyFor(getTextFunc(items[1]));
     elseif #items > 1 then
         for _, item in ipairs(items) do
             value = value == "" and tostring(item) or value.."/"..tostring(item);

--- a/textures/texname.lua
+++ b/textures/texname.lua
@@ -98,8 +98,12 @@ for retailTexture, classicTexture in pairs(mapping) do
   local filename = classicTexture:gsub(" ", "_"):gsub("'", "");
   local fullTextureName = "Interface\\Addons\\SpellActivationOverlay\\textures\\"..filename;
   local retailNumber = tonumber(retailTexture, 10);
-  if SAO.IsCata() and retailNumber <= 511469 and -- Cataclysm game files embed textures up to (at least) 511469
-    retailNumber ~= 450914 and retailNumber ~= 450915 then -- Eclipse textures in Cataclysm were different
+  if (
+    (SAO.IsCata() and retailNumber <= 511469) -- Cataclysm game files embed textures up to (at least) 511469
+    or
+    (SAO.IsMoP() and retailNumber <= 898423) -- Mists of Pandaria game files embed textures up to (at least) 898423
+  ) and
+    retailNumber ~= 450914 and retailNumber ~= 450915 then -- Eclipse textures in Cataclysm and Pandaria were different
     -- In this case, use texture embedded in game using its FileDataID, not from addon folder using a file path
     fullTextureName = retailTexture;
   end

--- a/variables/talent.lua
+++ b/variables/talent.lua
@@ -2,7 +2,7 @@ local AddonName, SAO = ...
 local Module = "talent"
 
 -- Optimize frequent calls
-local GetTalentInfo = GetTalentInfo
+local GetSpecialization = C_SpecializationInfo and C_SpecializationInfo.GetSpecialization
 
 -- Has spent point in the talent tree
 local HASH_TALENT_NO   = 0x40
@@ -66,8 +66,25 @@ SAO.Variable:register({
         fetchAndSet = function(bucket)
             if bucket.talentTabIndex then
                 local tab, index = bucket.talentTabIndex[1], bucket.talentTabIndex[2];
-                local rank = select(5, GetTalentInfo(tab, index));
+                local rank = SAO:GetNbTalentPoints(tab, index);
                 bucket:setTalented(rank > 0);
+            elseif bucket.talentTierColumn then
+                local tier, column = bucket.talentTierColumn[1], bucket.talentTierColumn[2];
+                local rank = SAO:GetNbTalentPoints(tier, column);
+                bucket:setTalented(rank > 0);
+            elseif bucket.talentSpec then
+                local currentSpec = GetSpecialization();
+                bucket:setTalented(currentSpec == bucket.talentSpec);
+            elseif bucket.talentSpecs then
+                -- When checking a list of specs, at least one spec must match
+                local currentSpec = GetSpecialization();
+                for spec in ipairs(bucket.talentSpecs) do
+                    if spec == currentSpec then
+                        bucket:setTalented(true);
+                        return;
+                    end
+                end
+                bucket:setTalented(false);
             elseif bucket.talentRuneID then
                 local hasRune = C_Engraving.IsRuneEquipped(bucket.talentRuneID);
                 bucket:setTalented(hasRune);
@@ -79,11 +96,25 @@ SAO.Variable:register({
 
     event = {
         isRequired = true,
-        names = SAO.IsSoD() and { "PLAYER_TALENT_UPDATE", "RUNE_UPDATED", "PLAYER_EQUIPMENT_CHANGED" } or { "PLAYER_TALENT_UPDATE" },
+        names =
+            (SAO.IsSoD() and { "PLAYER_TALENT_UPDATE", "RUNE_UPDATED", "PLAYER_EQUIPMENT_CHANGED" })
+            or
+            (SAO.IsMoP() and { "PLAYER_TALENT_UPDATE", "PLAYER_SPECIALIZATION_CHANGED" })
+            or
+            ({ "PLAYER_TALENT_UPDATE" })
+        ,
         PLAYER_TALENT_UPDATE = function(...)
             local buckets = SAO:GetBucketsByTrigger(SAO.TRIGGER_TALENT);
             for _, bucket in ipairs(buckets or {}) do
-                if bucket.talentTabIndex then -- Keep only talent-based buckets
+                if bucket.talentTabIndex or bucket.talentTierColumn then -- Refresh only talent-based buckets
+                    bucket.trigger:manualCheck(SAO.TRIGGER_TALENT);
+                end
+            end
+        end,
+        PLAYER_SPECIALIZATION_CHANGED = function(...)
+            local buckets = SAO:GetBucketsByTrigger(SAO.TRIGGER_TALENT);
+            for _, bucket in ipairs(buckets or {}) do
+                if bucket.talentSpec or bucket.talentSpecs then -- Refresh only spec-based buckets
                     bucket.trigger:manualCheck(SAO.TRIGGER_TALENT);
                 end
             end
@@ -91,7 +122,7 @@ SAO.Variable:register({
         RUNE_UPDATED = function(rune) -- Cannot rely on rune contents, because we need to refresh even if rune is un-equipped
             local buckets = SAO:GetBucketsByTrigger(SAO.TRIGGER_TALENT);
             for _, bucket in ipairs(buckets or {}) do
-                if bucket.talentRuneID then -- Keep only rune-based buckets
+                if bucket.talentRuneID then -- Refresh only rune-based buckets
                     bucket.trigger:manualCheck(SAO.TRIGGER_TALENT);
                 end
             end
@@ -99,7 +130,7 @@ SAO.Variable:register({
         PLAYER_EQUIPMENT_CHANGED = function(equipmentSlot, hasCurrent)
             local buckets = SAO:GetBucketsByTrigger(SAO.TRIGGER_TALENT);
             for _, bucket in ipairs(buckets or {}) do
-                if bucket.talentRuneID then -- Keep only rune-based buckets
+                if bucket.talentRuneID then -- Refresh only rune-based buckets
                     bucket.trigger:manualCheck(SAO.TRIGGER_TALENT);
                 end
             end
@@ -123,41 +154,70 @@ SAO.Variable:register({
             expectedType = "number",
             default = function(effect) return effect.spellID end,
             prepareBucket = function(bucket, value)
-                local talentName = GetSpellInfo(value);
-                local _, _, tab, index = SAO:GetTalentByName(talentName);
-                if type(tab) == 'number' and type(index) == 'number' then
-                    -- Talent Tab-Index is an option object { tab, index } telling the talent location in the player's tree
-                    bucket.talentTabIndex = { tab, index };
-                else
-                    if SAO.IsSoD() then -- For Season of Discovery, don't give up if the talent is not found, for it may be a rune
-                        bucket.talentRuneID = SAO:GetRuneFromSpell(value);
-                        if not bucket.talentRuneID then
-                            -- May not be found immediately, because of slow initialization
-                            -- Until we know of a guaranteed event that finalizes rune knowledge, our best bet is to retry over time
-                            bucket.talentRuneNbRetries = 5;
-                            bucket.talentRuneRetryTicker = C_Timer.NewTicker(
-                                1,
-                                function()
-                                    bucket.talentRuneNbRetries = bucket.talentRuneNbRetries - 1;
-                                    local runeID = SAO:GetRuneFromSpell(value);
-                                    if runeID then
-                                        -- Found it, yay!
-                                        bucket.talentRuneRetryTicker:Cancel();
-                                        bucket.talentRuneID = runeID;
-                                        bucket.trigger:manualCheck(SAO.TRIGGER_TALENT); -- Manual check because this code happens after prepareBucket returned
-                                    elseif bucket.talentRuneNbRetries == 0 then
-                                        -- Not found after retrying several times, bummer.
-                                        bucket.talentRuneRetryTicker:Cancel();
-                                        SAO:Error(Module, bucket.description.." requires talent or rune "..value..(talentName and " ("..talentName..")" or "")..
-                                                          ", but it cannot be found, neither in the talent tree nor in the rune set");
-                                    end
-                                end
-                            );
-                        end
-                    else
-                        SAO:Error(Module, bucket.description.." requires talent "..value..(talentName and " ("..talentName..")" or "")..", but it cannot be found in the talent tree");
+                if value < 0 then
+                    -- Negative values are focused on specializations instead of talents
+                    if not SAO.IsMoP() or not C_SpecializationInfo or not C_SpecializationInfo.IsInitialized() then
+                        SAO:Error(Module, bucket.description.." calls for specialization "..value.." but specializations are unavailable"); return;
                     end
+
+                    local specs = SAO:GetSpecsFromTalent(value);
+                    if not specs or #specs == 0 then
+                        SAO:Error(Module, bucket.description.." requires specialization "..value..", but it cannot be mapped to an actual specialization"); return;
+                    elseif #specs == 1 then
+                        bucket.talentSpec = specs[1];
+                    else
+                        bucket.talentSpecs = specs;
+                    end
+
+                    return;
                 end
+
+                -- Positive values have to be a talent's spell ID
+                local talentName = GetSpellInfo(value);
+                local _, _, i, j = SAO:GetTalentByName(talentName);
+                if type(i) == 'number' and type(j) == 'number' then
+                    if SAO.IsMoP() then
+                        -- Talent Tier-Column is an optional table { tier, column } telling the talent location in the player's talent table
+                        local tier, column = i, j;
+                        bucket.talentTierColumn = { tier, column };
+                    else
+                        -- Talent Tab-Index is an optional table { tab, index } telling the talent location in the player's talent tree
+                        local tab, index = i, j;
+                        bucket.talentTabIndex = { tab, index };
+                    end
+                    return;
+                end
+
+                -- For Season of Discovery, don't give up if the talent is not found, for it may be a rune
+                if SAO.IsSoD() then
+                    bucket.talentRuneID = SAO:GetRuneFromSpell(value);
+                    if not bucket.talentRuneID then
+                        -- May not be found immediately, because of slow initialization
+                        -- Until we know of a guaranteed event that finalizes rune knowledge, our best bet is to retry over time
+                        bucket.talentRuneNbRetries = 5;
+                        bucket.talentRuneRetryTicker = C_Timer.NewTicker(
+                            1,
+                            function()
+                                bucket.talentRuneNbRetries = bucket.talentRuneNbRetries - 1;
+                                local runeID = SAO:GetRuneFromSpell(value);
+                                if runeID then
+                                    -- Found it, yay!
+                                    bucket.talentRuneRetryTicker:Cancel();
+                                    bucket.talentRuneID = runeID;
+                                    bucket.trigger:manualCheck(SAO.TRIGGER_TALENT); -- Manual check because this code happens after prepareBucket returned
+                                elseif bucket.talentRuneNbRetries == 0 then
+                                    -- Not found after retrying several times, bummer.
+                                    bucket.talentRuneRetryTicker:Cancel();
+                                    SAO:Error(Module, bucket.description.." requires talent or rune "..value..(talentName and " ("..talentName..")" or "")..
+                                                        ", but it cannot be found, neither in the talent tree nor in the rune set");
+                                end
+                            end
+                        );
+                    end
+                    return;
+                end
+
+                SAO:Error(Module, bucket.description.." requires talent "..value..(talentName and " ("..talentName..")" or "")..", but it cannot be found in the talent tree");
             end,
         },
         classes = {


### PR DESCRIPTION
Introduces the Mists of Pandaria flavor.

The talent system, especially the talent 'variable', has been reworked in accordance with Mists of Pandaria's Talent rework i.e. players now have a specialization, and the talent tree has been replaced by a table table / talent grid.

A few class effects have been supported for testing purposes, but this Pull Request is definitely not an exhaustive support for all classes.

A new concept 'Disabled Class' has been added to indicate classes that have been temporarily disabled, as opposed to 'Unsupported Class' which represents classes without any support whatsoever. Many classes have been flagged as Disabled for Mists of Pandaria. As of today, the only class flagged as Unsupported is the Monk class.