### PR TITLE
Fix action button hooks on Titan Reforged 3.80.1

### DIFF
--- a/SpellActivationOverlay.toc
+++ b/SpellActivationOverlay.toc
@@ -1,4 +1,4 @@
-## Interface: 11509, 20506, 30405, 38000, 40402, 50504, 120000
+## Interface: 11509, 20506, 30405, 38000, 38001, 40402, 50504, 120000
 ## Title: |TInterface/Icons/Spell_Frost_Stun:16:16:0:0:512:512:64:448:64:448|t SpellActivationOverlay |cff66bbff2.7.10|r |TInterface/Icons/trade_engineering:16:16:0:0:512:512:32:480:32:480|t
 ## Notes: Display overlays and glow buttons to improve your gameplay!
 ## Notes-deDE: Zeigt Overlays und leuchtende Schaltflächen zur Verbesserung Ihres Gameplays an!

--- a/_script/package.sh
+++ b/_script/package.sh
@@ -349,7 +349,7 @@ fi
 
 # Release wrath version
 release_wrath() {
-WRATH_BUILD_VERSION="30405, 38000"
+WRATH_BUILD_VERSION="30405, 38000, 38001"
 mkproject wrath "$WRATH_BUILD_VERSION" 40abff achievement_boss_lichking 64 "Wrath of the Lich King"
 
 VARIABLES_NOT_FOR_WRATH=(holypower nativesao)

--- a/components/glow.lua
+++ b/components/glow.lua
@@ -399,7 +399,20 @@ local function HookActionButton_Update(button)
     end
     SAO:UpdateActionButton(button);
 end
-if SAO.HasMidnightUI() then
+
+local HookedActionButtons = {};
+local function HookActionButtonUpdateMethod(button)
+    if button and not HookedActionButtons[button] and type(button.Update) == "function" then
+        HookedActionButtons[button] = true;
+        hooksecurefunc(button, "Update", HookActionButton_Update);
+    end
+end
+
+if type(ActionButton_Update) == "function" then
+    -- Legacy action bars have a single entry point that updates all native ActionButton instances
+    hooksecurefunc("ActionButton_Update", HookActionButton_Update);
+else
+    -- Newer action bars, including Titan Reforged, update each ActionButton instance separately
     local actionBars = {
         -- https://www.townlong-yak.com/framexml/anniversary/Blizzard_ActionBar/MainActionBar.xml
         MainActionBar,
@@ -424,17 +437,28 @@ if SAO.HasMidnightUI() then
         -- https://www.townlong-yak.com/framexml/anniversary/Blizzard_ActionBar/PetActionBar.xml
         -- PetActionBar,
     };
-    for index, actionBar in ipairs(actionBars) do
-        if not actionBar then --[[BEGIN_DEV_ONLY]]
-            SAO:Error(Module, "Missing action bar: "..tostring(index));
-        end --[[END_DEV_ONLY]]
-        for _, actionButton in ipairs(actionBar and actionBar.actionButtons or {}) do
-            hooksecurefunc(actionButton, "Update", HookActionButton_Update);
+    for _, actionBar in pairs(actionBars) do
+        for _, actionButton in pairs(actionBar.actionButtons or {}) do
+            HookActionButtonUpdateMethod(actionButton);
         end
     end
-else
-    -- In other flavors of WoW Classic, there is a single entry point that updates all native ActionButton instances
-    hooksecurefunc("ActionButton_Update", HookActionButton_Update);
+
+    -- Some clients do not expose the actionButtons collection on their bar frames
+    local actionButtonPrefixes = {
+        "ActionButton",
+        "MultiBarBottomLeftButton",
+        "MultiBarBottomRightButton",
+        "MultiBarRightButton",
+        "MultiBarLeftButton",
+        "MultiBar5Button",
+        "MultiBar6Button",
+        "MultiBar7Button",
+    };
+    for _, prefix in ipairs(actionButtonPrefixes) do
+        for index = 1, NUM_ACTIONBAR_BUTTONS or 12 do
+            HookActionButtonUpdateMethod(_G[prefix..index]);
+        end
+    end
 end
 
 -- Grab buttons in the stance bar
@@ -473,7 +497,7 @@ local function HookStanceBar_UpdateState()
 end
 if select(2, UnitClass("player")) == "PRIEST" then
     -- Only Priests require hooking to StanceBar_UpdateState, for Shadowform
-    if not SAO.HasMidnightUI() then
+    if type(StanceBar_UpdateState) == "function" then
         -- Note: Shadow Priests do not have 'stances' in TBC, but we might need to fix it for Retail
         hooksecurefunc("StanceBar_UpdateState", HookStanceBar_UpdateState);
     end
@@ -786,7 +810,7 @@ binder:SetScript("OnEvent", function()
             local bar = _G["DominosFrame"..i];
             if bar and bar.buttons then
                 for _, button in pairs(bar.buttons) do
-                    hooksecurefunc(button, "Update", HookActionButton_Update);
+                    HookActionButtonUpdateMethod(button);
                 end
             end
         end

--- a/components/project.lua
+++ b/components/project.lua
@@ -54,6 +54,7 @@ end
 -- UI has changed in Midnight
 -- Also applies to WoW Classic:
 -- - TBC Classic Anniversary
+-- - Titan Reforged, starting with 3.80.1
 -- - MoP Classic, starting with SoO patch
 local hasMidnightUI = nil;
 function SAO.HasMidnightUI()
@@ -62,9 +63,11 @@ function SAO.HasMidnightUI()
     end
 
     local buildInfo = tonumber((select(2, GetBuildInfo())));
+    local interfaceVersion = tonumber((select(4, GetBuildInfo())));
     hasMidnightUI = (SAO.IsWoD()) -- Soon(tm)
                  or (SAO.IsMoP() and buildInfo >= 68042) -- 68042 = first build number of MoP Classic SoO patch
                  or (SAO.IsTBC() and buildInfo >= 65295) -- 65295 = first build number of TBC Classic Anniversary
+                 or (SAO.IsWrath() and interfaceVersion >= 38001) -- 38001 = interface version of Titan Reforged 3.80.1
                  or (SAO.IsEra() and buildInfo >= 68808) -- 68808 = first build number of Era with 'Midnight UI'
                  or (SAO.IsRetail() and LE_EXPANSION_LEVEL_CURRENT >= LE_EXPANSION_MIDNIGHT);
 


### PR DESCRIPTION
## Summary

- add support for the CN Titan Reforged 3.80.1 client (`Interface 38001`), a Wrath Classic-derived client
- select action-button hooks through API feature detection
- hook per-button `Update` methods when the legacy global `ActionButton_Update` function is unavailable
- guard the optional legacy stance update hook and avoid duplicate button hooks
- include `38001` in the addon TOC and Wrath package metadata

## Root cause

Unlike earlier Wrath Classic builds, the CN Titan Reforged 3.80.1 client no longer exposes the global `ActionButton_Update` function. `glow.lua` therefore selected an incompatible legacy hook and called:

```lua
hooksecurefunc("ActionButton_Update", HookActionButton_Update)
```

This failed during addon loading with `hooksecurefunc(): ActionButton_Update is not a function`.

The hook selection now checks which action-button API is actually available. Legacy clients continue using the global hook when it exists, while 3.80.1 hooks the `Update` method on individual action buttons.

`HasMidnightUI()` is an existing internal compatibility label in this addon for newer UI APIs that are also present in some Classic clients. Its use here does not identify Titan Reforged as Retail Midnight; Titan Reforged remains a Wrath Classic-derived client.

## Validation

- packaged the Wrath variant with `_script/package.sh wrath`
- verified the generated archive contains 112 entries and declares `## Interface: 30405, 38000, 38001`
- ran `git -c core.whitespace=cr-at-eol diff --check`
- tested the packaged addon in the live CN Titan Reforged 3.80.1 client; the original load error no longer occurs

Related context: #476
